### PR TITLE
Not breaking line makes it harder to read when errors repeatedly occur.

### DIFF
--- a/src/urdf_parser_py/xml_reflection/core.py
+++ b/src/urdf_parser_py/xml_reflection/core.py
@@ -21,7 +21,7 @@ def reflect(cls, *args, **kwargs):
 # How to incorporate line number and all that jazz?
 def on_error(message):
 	""" What to do on an error. This can be changed to raise an exception. """
-	sys.stderr.write(message)
+	sys.stderr.write(message + '\n')
 
 skip_default = True
 #defaultIfMatching = True # Not implemeneted yet


### PR DESCRIPTION
e.g. This is what is happening to me, which is hard to read:

```
Unknown tag: hardwareInterfaceUnknown tag: hardwareInterfaceUnknown tag: hardwareInterfaceUnknown tag: hardwareInterfaceUnknown tag: hardwareInterfaceUnknown tag: hardwareInterfaceUnknown tag: hardwareInterfaceUnknown tag: hardwareInterfaceUnknown tag: hardwareInterfaceUnknown tag: hardwareInterfaceUnknown tag: hardwareInterfaceUnknown tag: hardwareInterfaceUnknown tag: hardwareInterfaceFailed to get Item(global_collision_world): Ignored

$ rospack find urdfdom_py
/opt/ros/indigo/share/urdfdom_py
$ dpkg -p ros-indigo-urdfdom-py | grep Ver
Version: 0.3.1-1trusty-20160321-175123-0700
```

