### PR TITLE
Revert local line break now that more generic solution is merged.

### DIFF
--- a/src/urdf_parser_py/urdf.py
+++ b/src/urdf_parser_py/urdf.py
@@ -161,7 +161,7 @@ class Material(xmlr.Object):
 	
 	def check_valid(self):
 		if self.color is None and self.texture is None:
-			xmlr.on_error("Material has neither a color nor texture.\n")
+			xmlr.on_error("Material has neither a color nor texture.")
 
 xmlr.reflect(Material, params = [
 	name_attribute,


### PR DESCRIPTION
Now that more generic solution (https://github.com/ros/urdf_parser_py/pull/4) is merged, local line break https://github.com/ros/urdfdom/pull/77 duplicates line breaks and is not needed.
