### PR TITLE
Make unit test run with `catkin_make run_tests`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,17 +2,14 @@ cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
 project(urdfdom_py)
 
 find_package(catkin REQUIRED)
-catkin_python_setup()
 catkin_package()
+
+catkin_python_setup()
 
 catkin_install_python(PROGRAMS
   scripts/display_urdf
   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )
-
-set(SETUP_PY "${CMAKE_CURRENT_SOURCE_DIR}/setup.py")
-install(CODE "execute_process(COMMAND \"${PYTHON}\" \"${SETUP_PY}\" build --build-base \"${CMAKE_CURRENT_BINARY_DIR}/pybuild\" install --install-layout deb --prefix \"${CMAKE_INSTALL_PREFIX}\"
-              WORKING_DIRECTORY \"${CMAKE_CURRENT_SOURCE_DIR}\")")
 
 if (CATKIN_ENABLE_TESTING)
   catkin_add_nosetests(test/test_urdf.py)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,12 +1,6 @@
 cmake_minimum_required( VERSION 2.8 FATAL_ERROR )
 project(urdfdom_py)
 
-find_program(PYTHON "python")
-
-if (NOT PYTHON)
-  return()
-endif()
-
 find_package(catkin REQUIRED)
 catkin_python_setup()
 catkin_package()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,8 +20,6 @@ set(SETUP_PY "${CMAKE_CURRENT_SOURCE_DIR}/setup.py")
 install(CODE "execute_process(COMMAND \"${PYTHON}\" \"${SETUP_PY}\" build --build-base \"${CMAKE_CURRENT_BINARY_DIR}/pybuild\" install --install-layout deb --prefix \"${CMAKE_INSTALL_PREFIX}\"
               WORKING_DIRECTORY \"${CMAKE_CURRENT_SOURCE_DIR}\")")
 
-enable_testing()
-
-add_test(NAME urdf_parser_py
-         COMMAND /usr/bin/env PYTHONPATH=${CMAKE_CURRENT_SOURCE_DIR}/src ${PYTHON} test_urdf.py
-         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/test)
+if (CATKIN_ENABLE_TESTING)
+  catkin_add_nosetests(test/test_urdf.py)
+endif()

--- a/package.xml
+++ b/package.xml
@@ -29,6 +29,7 @@
   <run_depend>catkin</run_depend>
   <run_depend>python</run_depend>
   <run_depend>python-lxml</run_depend>
+  <run_depend>python-yaml</run_depend>
 
   <test_depend>python-mock</test_depend>
 

--- a/package.xml
+++ b/package.xml
@@ -29,4 +29,7 @@
   <run_depend>catkin</run_depend>
   <run_depend>python</run_depend>
   <run_depend>python-lxml</run_depend>
+
+  <test_depend>python-mock</test_depend>
+
 </package>

--- a/package.xml
+++ b/package.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<package>
+<package format="2">
   <name>urdfdom_py</name>
   <version>0.3.3</version>
   <description>Python implementation of the URDF parser.</description>
@@ -17,19 +17,16 @@
   <maintainer email="clalancette@osrfoundation.org">Chris Lalancette</maintainer>
   <maintainer email="sloretz@osrfoundation.org">Shane Loretz</maintainer>
 
-  <url type="website">http://wiki.ros.org/urdf_parser_py</url>
+  <url type="website">http://wiki.ros.org/urdfdom_py</url>
   <url type="bugtracker">https://github.com/ros/urdf_parser_py/issues</url>
   <url type="repository">https://github.com/ros/urdf_parser_py</url>
 
   <buildtool_depend>catkin</buildtool_depend>
-  <buildtool_depend>python-catkin-pkg</buildtool_depend>
 
-  <build_depend>python</build_depend>
+  <depend>python</depend>
 
-  <run_depend>catkin</run_depend>
-  <run_depend>python</run_depend>
-  <run_depend>python-lxml</run_depend>
-  <run_depend>python-yaml</run_depend>
+  <exec_depend>python-lxml</exec_depend>
+  <exec_depend>python-yaml</exec_depend>
 
   <test_depend>python-mock</test_depend>
 

--- a/test/test_urdf.py
+++ b/test/test_urdf.py
@@ -2,6 +2,12 @@ from __future__ import print_function
 
 import unittest
 import mock
+import os
+import sys
+
+# Add path to import xml_matching
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '.')))
+
 from xml.dom import minidom
 from xml_matching import xml_matches
 from urdf_parser_py import urdf

--- a/test/test_urdf.py
+++ b/test/test_urdf.py
@@ -7,6 +7,7 @@ import sys
 
 # Add path to import xml_matching
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '.')))
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '../src')))
 
 from xml.dom import minidom
 from xml_matching import xml_matches


### PR DESCRIPTION
I notice the unit tests wasn't running when using `catkin_make run_tests`. I changed how the test was added to use the catkin cmake macros. I also added python-mock as a test dependency because the official ubuntu/trusty docker image does not have that installed by default.