### PR TITLE
fixed defaults for xyz/rpy, fixed set_default for Param, added unit tests

### DIFF
--- a/src/urdf_parser_py/urdf.py
+++ b/src/urdf_parser_py/urdf.py
@@ -17,8 +17,9 @@ class Pose(xmlr.Object):
 		self.xyz = xyz
 		self.rpy = rpy
 	
-	def check_valid(self):
-		assert self.xyz is not None or self.rpy is not None
+	def check_valid(self):	    
+		assert self.xyz is None or len(self.xyz) == 3 and\
+         	   self.rpy is None or len(self.rpy) == 3
 	
 	# Aliases for backwards compatibility
 	@property
@@ -31,8 +32,8 @@ class Pose(xmlr.Object):
 	def position(self, value): self.xyz = value
 
 xmlr.reflect(Pose, params = [
-	xmlr.Attribute('xyz', 'vector3', False),
-	xmlr.Attribute('rpy', 'vector3', False)
+	xmlr.Attribute('xyz', 'vector3', False, default=[0, 0, 0]),
+	xmlr.Attribute('rpy', 'vector3', False, default=[0, 0, 0])
 	])
 
 

--- a/src/urdf_parser_py/urdf.py
+++ b/src/urdf_parser_py/urdf.py
@@ -16,11 +16,11 @@ class Pose(xmlr.Object):
 	def __init__(self, xyz=None, rpy=None):
 		self.xyz = xyz
 		self.rpy = rpy
-	
-	def check_valid(self):	    
+
+	def check_valid(self):
 		assert self.xyz is None or len(self.xyz) == 3 and\
-         	   self.rpy is None or len(self.rpy) == 3
-	
+		self.rpy is None or len(self.rpy) == 3
+
 	# Aliases for backwards compatibility
 	@property
 	def rotation(self): return self.rpy

--- a/src/urdf_parser_py/urdf.py
+++ b/src/urdf_parser_py/urdf.py
@@ -18,8 +18,8 @@ class Pose(xmlr.Object):
 		self.rpy = rpy
 
 	def check_valid(self):
-		assert self.xyz is None or len(self.xyz) == 3 and\
-		self.rpy is None or len(self.rpy) == 3
+		assert self.xyz is None or len(self.xyz) == 3 and \
+			self.rpy is None or len(self.rpy) == 3
 
 	# Aliases for backwards compatibility
 	@property

--- a/src/urdf_parser_py/xml_reflection/core.py
+++ b/src/urdf_parser_py/xml_reflection/core.py
@@ -23,7 +23,7 @@ def on_error(message):
 	""" What to do on an error. This can be changed to raise an exception. """
 	sys.stderr.write(message + '\n')
 
-skip_default = True
+skip_default = False
 #defaultIfMatching = True # Not implemeneted yet
 
 # Registering Types
@@ -243,7 +243,7 @@ class Param(object):
 		self.required = required
 		self.is_aggregate = False
 	
-	def set_default(self):
+	def set_default(self, obj):
 		if self.required:
 			raise Exception("Required {} not set in XML: {}".format(self.type, self.xml_var))
 		elif not skip_default:
@@ -312,7 +312,7 @@ class AggregateElement(Element):
 		value = self.value_type.from_xml(node)
 		obj.add_aggregate(self.xml_var, value)
 	
-	def set_default(self):
+	def set_default(self, obj):
 		pass
 	
 
@@ -387,7 +387,6 @@ class Reflection(object):
 		# Make this a map instead? Faster access? {name: isSet} ?
 		unset_attributes = list(self.attribute_map.keys())
 		unset_scalars = copy.copy(self.scalarNames)
-		
 		# Better method? Queues?
 		for xml_var in copy.copy(info.attributes):
 			attribute = self.attribute_map.get(xml_var)
@@ -413,10 +412,10 @@ class Reflection(object):
 				info.children.remove(child)
 		
 		for attribute in map(self.attribute_map.get, unset_attributes):
-			attribute.set_default()
+			attribute.set_default(obj)
 			
 		for element in map(self.element_map.get, unset_scalars):
-			element.set_default()
+			element.set_default(obj)
 		
 		if is_final:
 			for xml_var in info.attributes:

--- a/test/test_urdf.py
+++ b/test/test_urdf.py
@@ -141,5 +141,42 @@ class TestURDFParser(unittest.TestCase):
         self.assertRaises(ParseException, self.parse, xml)
 
 
+class LinkOriginTestCase(unittest.TestCase):
+    @mock.patch('urdf_parser_py.xml_reflection.on_error',
+                mock.Mock(side_effect=ParseException))
+    def parse(self, xml):
+        return urdf.Robot.from_xml_string(xml)
+
+    def test_robot_link_defaults(self):
+        xml = '''<?xml version="1.0"?>
+<robot name="test">
+  <link name="test_link">
+    <inertial>
+      <mass value="10.0"/>
+      <origin/>
+    </inertial>
+  </link>
+</robot>'''
+        robot = self.parse(xml)
+        origin = robot.links[0].inertial.origin
+        self.assertEquals(origin.xyz, [0, 0, 0])
+        self.assertEquals(origin.rpy, [0, 0, 0])
+
+    def test_robot_link_defaults_xyz_set(self):
+        xml = '''<?xml version="1.0"?>
+<robot name="test">
+  <link name="test_link">
+    <inertial>
+      <mass value="10.0"/>
+      <origin xyz="1 2 3"/>
+    </inertial>
+  </link>
+</robot>'''
+        robot = self.parse(xml)
+        origin = robot.links[0].inertial.origin
+        self.assertEquals(origin.xyz, [1, 2, 3])
+        self.assertEquals(origin.rpy, [0 ,0, 0])
+    
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
urdf default values for attributes/elements was not working at all.
I've fixed that by adding a corresponding param to set_default.

Currently origin xyz and rpy attributes do not have default values , although they are documented as having ones. This affects kdl_parse_py, for example. There is a simple patch to fix this in the following pull request, but the issue with xyz/rpy behaviour would be unsolved that way.

https://github.com/ros/robot_model/pull/187