### PR TITLE
Reformat python code to pep8 standard

### DIFF
--- a/scripts/display_urdf
+++ b/scripts/display_urdf
@@ -6,8 +6,10 @@ import argparse
 from urdf_parser_py.urdf import URDF
 
 parser = argparse.ArgumentParser(usage='Load an URDF file')
-parser.add_argument('file', type=argparse.FileType('r'), nargs='?', default=None, help='File to load. Use - for stdin')
-parser.add_argument('-o', '--output', type=argparse.FileType('w'), default=None, help='Dump file to XML')
+parser.add_argument('file', type=argparse.FileType('r'), nargs='?',
+                    default=None, help='File to load. Use - for stdin')
+parser.add_argument('-o', '--output', type=argparse.FileType('w'),
+                    default=None, help='Dump file to XML')
 args = parser.parse_args()
 
 if args.file is None:

--- a/src/urdf_parser_py/sdf.py
+++ b/src/urdf_parser_py/sdf.py
@@ -5,117 +5,128 @@ import urdf_parser_py.xml_reflection as xmlr
 
 xmlr.start_namespace('sdf')
 
+
 class Pose(xmlr.Object):
-	def __init__(self, vec=None, extra=None):
-		self.xyz = None
-		self.rpy = None
-		if vec is not None:
-			assert isinstance(vec, list)
-			count = len(vec)
-			if len == 3:
-				xyz = vec
-			else:
-				self.from_vec(vec)
-		elif extra is not None:
-			assert xyz is None, "Cannot specify 6-length vector and 3-length vector"
-			assert len(extra) == 3, "Invalid length"
-			self.rpy = extra
-	
-	def from_vec(self, vec):
-		assert len(vec) == 6, "Invalid length"
-		self.xyz = vec[:3]
-		self.rpy = vec[3:6]
-	
-	def as_vec(self):
-		xyz = self.xyz if self.xyz else [0, 0, 0]
-		rpy = self.rpy if self.rpy else [0, 0, 0]
-		return xyz + rpy
-	
-	def read_xml(self, node):
-		# Better way to do this? Define type?
-		vec = get_type('vector6').read_xml(node)
-		self.load_vec(vec)
-	
-	def write_xml(self, node):
-		vec = self.as_vec()
-		get_type('vector6').write_xml(node, vec)
-	
-	def check_valid(self):
-		assert self.xyz is not None or self.rpy is not None
+    def __init__(self, vec=None, extra=None):
+        self.xyz = None
+        self.rpy = None
+        if vec is not None:
+            assert isinstance(vec, list)
+            count = len(vec)
+            if len == 3:
+                xyz = vec
+            else:
+                self.from_vec(vec)
+        elif extra is not None:
+            assert xyz is None, "Cannot specify 6-length vector and 3-length vector"  # noqa
+            assert len(extra) == 3, "Invalid length"
+            self.rpy = extra
+
+    def from_vec(self, vec):
+        assert len(vec) == 6, "Invalid length"
+        self.xyz = vec[:3]
+        self.rpy = vec[3:6]
+
+    def as_vec(self):
+        xyz = self.xyz if self.xyz else [0, 0, 0]
+        rpy = self.rpy if self.rpy else [0, 0, 0]
+        return xyz + rpy
+
+    def read_xml(self, node):
+        # Better way to do this? Define type?
+        vec = get_type('vector6').read_xml(node)
+        self.load_vec(vec)
+
+    def write_xml(self, node):
+        vec = self.as_vec()
+        get_type('vector6').write_xml(node, vec)
+
+    def check_valid(self):
+        assert self.xyz is not None or self.rpy is not None
+
 
 name_attribute = xmlr.Attribute('name', str)
 pose_element = xmlr.Element('pose', Pose, False)
 
-class Entity(xmlr.Object):
-	def __init__(self, name = None, pose = None):
-		self.name = name
-		self.pose = pose
 
-xmlr.reflect(Entity, params = [
-	name_attribute,
-	pose_element
-	])
+class Entity(xmlr.Object):
+    def __init__(self, name=None, pose=None):
+        self.name = name
+        self.pose = pose
+
+
+xmlr.reflect(Entity, params=[
+    name_attribute,
+    pose_element
+])
 
 
 class Inertia(xmlr.Object):
-	KEYS = ['ixx', 'ixy', 'ixz', 'iyy', 'iyz', 'izz']
-	
-	def __init__(self, ixx=0.0, ixy=0.0, ixz=0.0, iyy=0.0, iyz=0.0, izz=0.0):
-		self.ixx = ixx
-		self.ixy = ixy
-		self.ixz = ixz
-		self.iyy = iyy
-		self.iyz = iyz
-		self.izz = izz
-	
-	def to_matrix(self):
-		return [
-			[self.ixx, self.ixy, self.ixz],
-			[self.ixy, self.iyy, self.iyz],
-			[self.ixz, self.iyz, self.izz]]
+    KEYS = ['ixx', 'ixy', 'ixz', 'iyy', 'iyz', 'izz']
 
-xmlr.reflect(Inertia, params = [xmlr.Element(key, float) for key in Inertia.KEYS])
+    def __init__(self, ixx=0.0, ixy=0.0, ixz=0.0, iyy=0.0, iyz=0.0, izz=0.0):
+        self.ixx = ixx
+        self.ixy = ixy
+        self.ixz = ixz
+        self.iyy = iyy
+        self.iyz = iyz
+        self.izz = izz
+
+    def to_matrix(self):
+        return [
+            [self.ixx, self.ixy, self.ixz],
+            [self.ixy, self.iyy, self.iyz],
+            [self.ixz, self.iyz, self.izz]]
+
+
+xmlr.reflect(Inertia,
+             params=[xmlr.Element(key, float) for key in Inertia.KEYS])
 
 # Pretty much copy-paste... Better method?
 # Use multiple inheritance to separate the objects out so they are unique?
-class Inertial(xmlr.Object):
-	def __init__(self, mass = 0.0, inertia = None, pose=None):
-		self.mass = mass
-		self.inertia = inertia
-		self.pose = pose
 
-xmlr.reflect(Inertial, params = [
-	xmlr.Element('mass', float),
-	xmlr.Element('inertia', Inertia),
-	pose_element
-	])
+
+class Inertial(xmlr.Object):
+    def __init__(self, mass=0.0, inertia=None, pose=None):
+        self.mass = mass
+        self.inertia = inertia
+        self.pose = pose
+
+
+xmlr.reflect(Inertial, params=[
+    xmlr.Element('mass', float),
+    xmlr.Element('inertia', Inertia),
+    pose_element
+])
 
 
 class Link(Entity):
-	def __init__(self, name = None, pose = None, inertial = None, kinematic = False):
-		Entity.__init__(self, name, pose)
-		self.inertial = inertial
-		self.kinematic = kinematic
+    def __init__(self, name=None, pose=None, inertial=None, kinematic=False):
+        Entity.__init__(self, name, pose)
+        self.inertial = inertial
+        self.kinematic = kinematic
 
-xmlr.reflect(Link, parent_cls = Entity, params = [
-	xmlr.Element('inertial', Inertial),
-	xmlr.Attribute('kinematic', bool, False),
-	xmlr.AggregateElement('visual', Visual, var = 'visuals'),
-	xmlr.AggregateElement('collision', Collision, var = 'collisions')
-	])
+
+xmlr.reflect(Link, parent_cls=Entity, params=[
+    xmlr.Element('inertial', Inertial),
+    xmlr.Attribute('kinematic', bool, False),
+    xmlr.AggregateElement('visual', Visual, var='visuals'),
+    xmlr.AggregateElement('collision', Collision, var='collisions')
+])
 
 
 class Model(Entity):
-	def __init__(self, name = None, pose=None):
-		Entity.__init__(self, name, pose)
-		self.links = []
-		self.joints = []
-		self.plugins = []
+    def __init__(self, name=None, pose=None):
+        Entity.__init__(self, name, pose)
+        self.links = []
+        self.joints = []
+        self.plugins = []
 
-xmlr.reflect(Model, parent_cls = Entity, params = [
-	xmlr.AggregateElement('link', Link, var = 'links'),
-	xmlr.AggregateElement('joint', Joint, var = 'joints'),
-	xmlr.AggregateElement('plugin', Plugin, var = 'plugins')
-	])
+
+xmlr.reflect(Model, parent_cls=Entity, params=[
+    xmlr.AggregateElement('link', Link, var='links'),
+    xmlr.AggregateElement('joint', Joint, var='joints'),
+    xmlr.AggregateElement('plugin', Plugin, var='plugins')
+])
 
 xmlr.end_namespace('sdf')

--- a/src/urdf_parser_py/urdf.py
+++ b/src/urdf_parser_py/urdf.py
@@ -1,7 +1,7 @@
 from urdf_parser_py.xml_reflection.basics import *
 import urdf_parser_py.xml_reflection as xmlr
 
-# Add a 'namespace' for names so that things don't conflict between URDF and SDF?
+# Add a 'namespace' for names to avoid a conflict between URDF and SDF?
 # A type registry? How to scope that? Just make a 'global' type pointer?
 # Or just qualify names? urdf.geometric, sdf.geometric
 
@@ -12,473 +12,518 @@ xmlr.add_type('element_xyz', xmlr.SimpleElementType('xyz', 'vector3'))
 
 verbose = True
 
+
 class Pose(xmlr.Object):
-	def __init__(self, xyz=None, rpy=None):
-		self.xyz = xyz
-		self.rpy = rpy
+    def __init__(self, xyz=None, rpy=None):
+        self.xyz = xyz
+        self.rpy = rpy
 
-	def check_valid(self):
-		assert (self.xyz is None or len(self.xyz) == 3) and \
-			(self.rpy is None or len(self.rpy) == 3)
+    def check_valid(self):
+        assert (self.xyz is None or len(self.xyz) == 3) and \
+            (self.rpy is None or len(self.rpy) == 3)
 
-	# Aliases for backwards compatibility
-	@property
-	def rotation(self): return self.rpy
-	@rotation.setter
-	def rotation(self, value): self.rpy = value
-	@property
-	def position(self): return self.xyz
-	@position.setter
-	def position(self, value): self.xyz = value
+    # Aliases for backwards compatibility
+    @property
+    def rotation(self): return self.rpy
 
-xmlr.reflect(Pose, params = [
-	xmlr.Attribute('xyz', 'vector3', False, default=[0, 0, 0]),
-	xmlr.Attribute('rpy', 'vector3', False, default=[0, 0, 0])
-	])
+    @rotation.setter
+    def rotation(self, value): self.rpy = value
+
+    @property
+    def position(self): return self.xyz
+
+    @position.setter
+    def position(self, value): self.xyz = value
+
+
+xmlr.reflect(Pose, params=[
+    xmlr.Attribute('xyz', 'vector3', False, default=[0, 0, 0]),
+    xmlr.Attribute('rpy', 'vector3', False, default=[0, 0, 0])
+])
 
 
 # Common stuff
 name_attribute = xmlr.Attribute('name', str)
 origin_element = xmlr.Element('origin', Pose, False)
 
-class Color(xmlr.Object):
-	def __init__(self, *args):
-		# What about named colors?
-		count = len(args)
-		if count == 4 or count == 3:
-			self.rgba = args
-		elif count == 1:
-			self.rgba = args[0]
-		elif count == 0:
-			self.rgba = None
-		if self.rgba is not None:
-			if len(self.rgba) == 3:
-				self.rgba += [1.]
-			if len(self.rgba) != 4:
-				raise Exception('Invalid color argument count')
 
-xmlr.reflect(Color, params = [
-	xmlr.Attribute('rgba', 'vector4')
-	])
+class Color(xmlr.Object):
+    def __init__(self, *args):
+        # What about named colors?
+        count = len(args)
+        if count == 4 or count == 3:
+            self.rgba = args
+        elif count == 1:
+            self.rgba = args[0]
+        elif count == 0:
+            self.rgba = None
+        if self.rgba is not None:
+            if len(self.rgba) == 3:
+                self.rgba += [1.]
+            if len(self.rgba) != 4:
+                raise Exception('Invalid color argument count')
+
+
+xmlr.reflect(Color, params=[
+    xmlr.Attribute('rgba', 'vector4')
+])
 
 
 class JointDynamics(xmlr.Object):
-	def __init__(self, damping=None, friction=None):
-		self.damping = damping
-		self.friction = friction
+    def __init__(self, damping=None, friction=None):
+        self.damping = damping
+        self.friction = friction
 
-xmlr.reflect(JointDynamics, params = [
-	xmlr.Attribute('damping', float, False),
-	xmlr.Attribute('friction', float, False)
-	])
+
+xmlr.reflect(JointDynamics, params=[
+    xmlr.Attribute('damping', float, False),
+    xmlr.Attribute('friction', float, False)
+])
 
 
 class Box(xmlr.Object):
-	def __init__(self, size = None):
-		self.size = size
+    def __init__(self, size=None):
+        self.size = size
 
-xmlr.reflect(Box, params = [
-	xmlr.Attribute('size', 'vector3')
-	])
+
+xmlr.reflect(Box, params=[
+    xmlr.Attribute('size', 'vector3')
+])
 
 
 class Cylinder(xmlr.Object):
-	def __init__(self, radius = 0.0, length = 0.0):
-		self.radius = radius
-		self.length = length
+    def __init__(self, radius=0.0, length=0.0):
+        self.radius = radius
+        self.length = length
 
-xmlr.reflect(Cylinder, params = [
-	xmlr.Attribute('radius', float),
-	xmlr.Attribute('length', float)
-	])
+
+xmlr.reflect(Cylinder, params=[
+    xmlr.Attribute('radius', float),
+    xmlr.Attribute('length', float)
+])
 
 
 class Sphere(xmlr.Object):
-	def __init__(self, radius=0.0):
-		self.radius = radius
+    def __init__(self, radius=0.0):
+        self.radius = radius
 
-xmlr.reflect(Sphere, params = [
-	xmlr.Attribute('radius', float)
-	])
+
+xmlr.reflect(Sphere, params=[
+    xmlr.Attribute('radius', float)
+])
 
 
 class Mesh(xmlr.Object):
-	def __init__(self, filename = None, scale = None):
-		self.filename = filename
-		self.scale = scale
+    def __init__(self, filename=None, scale=None):
+        self.filename = filename
+        self.scale = scale
 
-xmlr.reflect(Mesh, params = [
-	xmlr.Attribute('filename', str),
-	xmlr.Attribute('scale', 'vector3', required=False)
-	])
+
+xmlr.reflect(Mesh, params=[
+    xmlr.Attribute('filename', str),
+    xmlr.Attribute('scale', 'vector3', required=False)
+])
 
 
 class GeometricType(xmlr.ValueType):
-	def __init__(self):
-		self.factory = xmlr.FactoryType('geometric', {
-			'box': Box,
-			'cylinder': Cylinder,
-			'sphere': Sphere,
-			'mesh': Mesh
-			})
-	
-	def from_xml(self, node):
-		children = xml_children(node)
-		assert len(children) == 1, 'One element only for geometric'
-		return self.factory.from_xml(children[0])
-	
-	def write_xml(self, node, obj):
-		name = self.factory.get_name(obj)
-		child = node_add(node, name)
-		obj.write_xml(child)
+    def __init__(self):
+        self.factory = xmlr.FactoryType('geometric', {
+            'box': Box,
+            'cylinder': Cylinder,
+            'sphere': Sphere,
+            'mesh': Mesh
+        })
+
+    def from_xml(self, node):
+        children = xml_children(node)
+        assert len(children) == 1, 'One element only for geometric'
+        return self.factory.from_xml(children[0])
+
+    def write_xml(self, node, obj):
+        name = self.factory.get_name(obj)
+        child = node_add(node, name)
+        obj.write_xml(child)
+
 
 xmlr.add_type('geometric', GeometricType())
 
-class Collision(xmlr.Object):
-	def __init__(self, geometry = None, origin = None):
-		self.geometry = geometry
-		self.origin = origin
 
-xmlr.reflect(Collision, params = [
-	origin_element,
-	xmlr.Element('geometry', 'geometric')
-	])
+class Collision(xmlr.Object):
+    def __init__(self, geometry=None, origin=None):
+        self.geometry = geometry
+        self.origin = origin
+
+
+xmlr.reflect(Collision, params=[
+    origin_element,
+    xmlr.Element('geometry', 'geometric')
+])
 
 
 class Texture(xmlr.Object):
-	def __init__(self, filename = None):
-		self.filename = filename
+    def __init__(self, filename=None):
+        self.filename = filename
 
-xmlr.reflect(Texture, params = [
-	xmlr.Attribute('filename', str)
-	])
+
+xmlr.reflect(Texture, params=[
+    xmlr.Attribute('filename', str)
+])
 
 
 class Material(xmlr.Object):
-	def __init__(self, name=None, color=None, texture=None):
-		self.name = name
-		self.color = color
-		self.texture = texture
-	
-	def check_valid(self):
-		if self.color is None and self.texture is None:
-			xmlr.on_error("Material has neither a color nor texture.")
+    def __init__(self, name=None, color=None, texture=None):
+        self.name = name
+        self.color = color
+        self.texture = texture
 
-xmlr.reflect(Material, params = [
-	name_attribute,
-	xmlr.Element('color', Color, False),
-	xmlr.Element('texture', Texture, False)
-	])
+    def check_valid(self):
+        if self.color is None and self.texture is None:
+            xmlr.on_error("Material has neither a color nor texture.")
+
+
+xmlr.reflect(Material, params=[
+    name_attribute,
+    xmlr.Element('color', Color, False),
+    xmlr.Element('texture', Texture, False)
+])
+
 
 class LinkMaterial(Material):
-	def check_valid(self):
-		pass
+    def check_valid(self):
+        pass
+
 
 class Visual(xmlr.Object):
-	def __init__(self, geometry = None, material = None, origin = None):
-		self.geometry = geometry
-		self.material = material
-		self.origin = origin
+    def __init__(self, geometry=None, material=None, origin=None):
+        self.geometry = geometry
+        self.material = material
+        self.origin = origin
 
-xmlr.reflect(Visual, params = [
-	origin_element,
-	xmlr.Element('geometry', 'geometric'),
-	xmlr.Element('material', LinkMaterial, False)
-	])
+
+xmlr.reflect(Visual, params=[
+    origin_element,
+    xmlr.Element('geometry', 'geometric'),
+    xmlr.Element('material', LinkMaterial, False)
+])
 
 
 class Inertia(xmlr.Object):
-	KEYS = ['ixx', 'ixy', 'ixz', 'iyy', 'iyz', 'izz']
-	
-	def __init__(self, ixx=0.0, ixy=0.0, ixz=0.0, iyy=0.0, iyz=0.0, izz=0.0):
-		self.ixx = ixx
-		self.ixy = ixy
-		self.ixz = ixz
-		self.iyy = iyy
-		self.iyz = iyz
-		self.izz = izz
-	
-	def to_matrix(self):
-		return [
-			[self.ixx, self.ixy, self.ixz],
-			[self.ixy, self.iyy, self.iyz],
-			[self.ixz, self.iyz, self.izz]]
+    KEYS = ['ixx', 'ixy', 'ixz', 'iyy', 'iyz', 'izz']
 
-xmlr.reflect(Inertia, params = [xmlr.Attribute(key, float) for key in Inertia.KEYS])
+    def __init__(self, ixx=0.0, ixy=0.0, ixz=0.0, iyy=0.0, iyz=0.0, izz=0.0):
+        self.ixx = ixx
+        self.ixy = ixy
+        self.ixz = ixz
+        self.iyy = iyy
+        self.iyz = iyz
+        self.izz = izz
+
+    def to_matrix(self):
+        return [
+            [self.ixx, self.ixy, self.ixz],
+            [self.ixy, self.iyy, self.iyz],
+            [self.ixz, self.iyz, self.izz]]
+
+
+xmlr.reflect(Inertia,
+             params=[xmlr.Attribute(key, float) for key in Inertia.KEYS])
 
 
 class Inertial(xmlr.Object):
-	def __init__(self, mass = 0.0, inertia = None, origin=None):
-		self.mass = mass
-		self.inertia = inertia
-		self.origin = origin
-
-xmlr.reflect(Inertial, params = [
-	origin_element,
-	xmlr.Element('mass', 'element_value'),
-	xmlr.Element('inertia', Inertia, False)
-	])
+    def __init__(self, mass=0.0, inertia=None, origin=None):
+        self.mass = mass
+        self.inertia = inertia
+        self.origin = origin
 
 
+xmlr.reflect(Inertial, params=[
+    origin_element,
+    xmlr.Element('mass', 'element_value'),
+    xmlr.Element('inertia', Inertia, False)
+])
 
-#FIXME: we are missing the reference position here.
+
+# FIXME: we are missing the reference position here.
 class JointCalibration(xmlr.Object):
-	def __init__(self, rising=None, falling=None):
-		self.rising = rising
-		self.falling = falling
+    def __init__(self, rising=None, falling=None):
+        self.rising = rising
+        self.falling = falling
 
-xmlr.reflect(JointCalibration, params = [
-	xmlr.Attribute('rising', float, False, 0),
-	xmlr.Attribute('falling', float, False, 0)
-	])
+
+xmlr.reflect(JointCalibration, params=[
+    xmlr.Attribute('rising', float, False, 0),
+    xmlr.Attribute('falling', float, False, 0)
+])
+
 
 class JointLimit(xmlr.Object):
-	def __init__(self, effort=None, velocity=None, lower=None, upper=None):
-		self.effort = effort
-		self.velocity = velocity
-		self.lower = lower
-		self.upper = upper
+    def __init__(self, effort=None, velocity=None, lower=None, upper=None):
+        self.effort = effort
+        self.velocity = velocity
+        self.lower = lower
+        self.upper = upper
 
-xmlr.reflect(JointLimit, params = [
-	xmlr.Attribute('effort', float),
-	xmlr.Attribute('lower', float, False, 0),
-	xmlr.Attribute('upper', float, False, 0),
-	xmlr.Attribute('velocity', float)
-	])
 
-#FIXME: we are missing __str__ here.
+xmlr.reflect(JointLimit, params=[
+    xmlr.Attribute('effort', float),
+    xmlr.Attribute('lower', float, False, 0),
+    xmlr.Attribute('upper', float, False, 0),
+    xmlr.Attribute('velocity', float)
+])
+
+# FIXME: we are missing __str__ here.
+
+
 class JointMimic(xmlr.Object):
-	def __init__(self, joint_name=None, multiplier=None, offset=None):
-		self.joint = joint_name
-		self.multiplier = multiplier
-		self.offset = offset	
+    def __init__(self, joint_name=None, multiplier=None, offset=None):
+        self.joint = joint_name
+        self.multiplier = multiplier
+        self.offset = offset
 
-xmlr.reflect(JointMimic, params = [
-	xmlr.Attribute('joint', str),
-	xmlr.Attribute('multiplier', float, False),
-	xmlr.Attribute('offset', float, False)
-	])
+
+xmlr.reflect(JointMimic, params=[
+    xmlr.Attribute('joint', str),
+    xmlr.Attribute('multiplier', float, False),
+    xmlr.Attribute('offset', float, False)
+])
+
 
 class SafetyController(xmlr.Object):
-	def __init__(self, velocity=None, position=None, lower=None, upper=None):
-		self.k_velocity = velocity
-		self.k_position = position
-		self.soft_lower_limit = lower
-		self.soft_upper_limit = upper
+    def __init__(self, velocity=None, position=None, lower=None, upper=None):
+        self.k_velocity = velocity
+        self.k_position = position
+        self.soft_lower_limit = lower
+        self.soft_upper_limit = upper
 
-xmlr.reflect(SafetyController, params = [
-	xmlr.Attribute('k_velocity', float),
-	xmlr.Attribute('k_position', float, False, 0),
-	xmlr.Attribute('soft_lower_limit', float, False, 0),
-	xmlr.Attribute('soft_upper_limit', float, False, 0)
-	])
+
+xmlr.reflect(SafetyController, params=[
+    xmlr.Attribute('k_velocity', float),
+    xmlr.Attribute('k_position', float, False, 0),
+    xmlr.Attribute('soft_lower_limit', float, False, 0),
+    xmlr.Attribute('soft_upper_limit', float, False, 0)
+])
+
 
 class Joint(xmlr.Object):
-	TYPES = ['unknown', 'revolute', 'continuous', 'prismatic', 'floating', 'planar', 'fixed']
+    TYPES = ['unknown', 'revolute', 'continuous', 'prismatic',
+             'floating', 'planar', 'fixed']
 
-	def __init__(self, name=None, parent=None, child=None, joint_type=None,
-			axis=None, origin=None,
-			limit=None, dynamics=None, safety_controller=None, calibration=None,
-			mimic=None):
-		self.name = name
-		self.parent = parent
-		self.child = child
-		self.type = joint_type
-		self.axis = axis
-		self.origin = origin
-		self.limit = limit
-		self.dynamics = dynamics
-		self.safety_controller = safety_controller
-		self.calibration = calibration
-		self.mimic = mimic
-	
-	def check_valid(self):
-		assert self.type in self.TYPES, "Invalid joint type: {}".format(self.type)
-	
-	# Aliases
-	@property
-	def joint_type(self): return self.type
-	@joint_type.setter
-	def joint_type(self, value): self.type = value
+    def __init__(self, name=None, parent=None, child=None, joint_type=None,
+                 axis=None, origin=None,
+                 limit=None, dynamics=None, safety_controller=None,
+                 calibration=None, mimic=None):
+        self.name = name
+        self.parent = parent
+        self.child = child
+        self.type = joint_type
+        self.axis = axis
+        self.origin = origin
+        self.limit = limit
+        self.dynamics = dynamics
+        self.safety_controller = safety_controller
+        self.calibration = calibration
+        self.mimic = mimic
 
-xmlr.reflect(Joint, params = [
-	name_attribute,
-	xmlr.Attribute('type', str),
-	origin_element,
-	xmlr.Element('axis', 'element_xyz', False),
-	xmlr.Element('parent', 'element_link'),
-	xmlr.Element('child', 'element_link'),
-	xmlr.Element('limit', JointLimit, False),
-	xmlr.Element('dynamics', JointDynamics, False),
-	xmlr.Element('safety_controller', SafetyController, False),
-	xmlr.Element('calibration', JointCalibration, False),
-	xmlr.Element('mimic', JointMimic, False),
-	])
+    def check_valid(self):
+        assert self.type in self.TYPES, "Invalid joint type: {}".format(self.type)  # noqa
+
+    # Aliases
+    @property
+    def joint_type(self): return self.type
+
+    @joint_type.setter
+    def joint_type(self, value): self.type = value
+
+xmlr.reflect(Joint, params=[
+    name_attribute,
+    xmlr.Attribute('type', str),
+    origin_element,
+    xmlr.Element('axis', 'element_xyz', False),
+    xmlr.Element('parent', 'element_link'),
+    xmlr.Element('child', 'element_link'),
+    xmlr.Element('limit', JointLimit, False),
+    xmlr.Element('dynamics', JointDynamics, False),
+    xmlr.Element('safety_controller', SafetyController, False),
+    xmlr.Element('calibration', JointCalibration, False),
+    xmlr.Element('mimic', JointMimic, False),
+])
 
 
 class Link(xmlr.Object):
-	def __init__(self, name=None, visual=None, inertial=None, collision=None, origin = None):
-		self.name = name
-		self.visual = visual
-		self.inertial = inertial
-		self.collision = collision
-		self.origin = origin
+    def __init__(self, name=None, visual=None, inertial=None, collision=None,
+                 origin=None):
+        self.name = name
+        self.visual = visual
+        self.inertial = inertial
+        self.collision = collision
+        self.origin = origin
 
-xmlr.reflect(Link, params = [
-	name_attribute,
-	origin_element,
-	xmlr.Element('inertial', Inertial, False),
-	xmlr.Element('visual', Visual, False),
-	xmlr.Element('collision', Collision, False)
-	])
+xmlr.reflect(Link, params=[
+    name_attribute,
+    origin_element,
+    xmlr.Element('inertial', Inertial, False),
+    xmlr.Element('visual', Visual, False),
+    xmlr.Element('collision', Collision, False)
+])
 
 
 class PR2Transmission(xmlr.Object):
-	def __init__(self, name = None, joint = None, actuator = None, type = None, mechanicalReduction = 1):
-		self.name = name
-		self.type = type
-		self.joint = joint
-		self.actuator = actuator
-		self.mechanicalReduction = mechanicalReduction
+    def __init__(self, name=None, joint=None, actuator=None, type=None,
+                 mechanicalReduction=1):
+        self.name = name
+        self.type = type
+        self.joint = joint
+        self.actuator = actuator
+        self.mechanicalReduction = mechanicalReduction
 
-xmlr.reflect(PR2Transmission, tag = 'pr2_transmission', params = [
-	name_attribute,
-	xmlr.Attribute('type', str),
-	xmlr.Element('joint', 'element_name'),
-	xmlr.Element('actuator', 'element_name'),
-	xmlr.Element('mechanicalReduction', float)
-	])
+
+xmlr.reflect(PR2Transmission, tag='pr2_transmission', params=[
+    name_attribute,
+    xmlr.Attribute('type', str),
+    xmlr.Element('joint', 'element_name'),
+    xmlr.Element('actuator', 'element_name'),
+    xmlr.Element('mechanicalReduction', float)
+])
 
 
 class Actuator(xmlr.Object):
-	def __init__(self, name = None, mechanicalReduction = 1):
-		self.name = name
-		self.mechanicalReduction = None
+    def __init__(self, name=None, mechanicalReduction=1):
+        self.name = name
+        self.mechanicalReduction = None
 
-xmlr.reflect(Actuator, tag = 'actuator', params = [
-		name_attribute,
-		xmlr.Element('mechanicalReduction', float, required = False)
-		])
+
+xmlr.reflect(Actuator, tag='actuator', params=[
+    name_attribute,
+    xmlr.Element('mechanicalReduction', float, required=False)
+])
+
 
 class TransmissionJoint(xmlr.Object):
-	def __init__(self, name = None):
-		self.aggregate_init()
-		self.name = name
-		self.hardwareInterfaces = []
+    def __init__(self, name=None):
+        self.aggregate_init()
+        self.name = name
+        self.hardwareInterfaces = []
 
-	def check_valid(self):
-		assert len(self.hardwareInterfaces) > 0, "no hardwareInterface defined"
+    def check_valid(self):
+        assert len(self.hardwareInterfaces) > 0, "no hardwareInterface defined"
 
 
-xmlr.reflect(TransmissionJoint, tag = 'joint', params = [
-		name_attribute,
-		xmlr.AggregateElement('hardwareInterface', str),
-		])
+xmlr.reflect(TransmissionJoint, tag='joint', params=[
+    name_attribute,
+    xmlr.AggregateElement('hardwareInterface', str),
+])
+
 
 class Transmission(xmlr.Object):
-	""" New format: http://wiki.ros.org/urdf/XML/Transmission """
-	def __init__(self, name = None):
-		self.aggregate_init()
-		self.name = name
-		self.joints = []
-		self.actuators = []
+    """ New format: http://wiki.ros.org/urdf/XML/Transmission """
 
-	def check_valid(self):
-		assert len(self.joints) > 0, "no joint defined"
-		assert len(self.actuators) > 0, "no actuator defined"
+    def __init__(self, name=None):
+        self.aggregate_init()
+        self.name = name
+        self.joints = []
+        self.actuators = []
 
-xmlr.reflect(Transmission, tag = 'new_transmission', params = [
-		name_attribute,
-		xmlr.Element('type', str),
-		xmlr.AggregateElement('joint', TransmissionJoint),
-		xmlr.AggregateElement('actuator', Actuator)
-		])
+    def check_valid(self):
+        assert len(self.joints) > 0, "no joint defined"
+        assert len(self.actuators) > 0, "no actuator defined"
 
-xmlr.add_type('transmission', xmlr.DuckTypedFactory('transmission', [Transmission, PR2Transmission]))
+
+xmlr.reflect(Transmission, tag='new_transmission', params=[
+    name_attribute,
+    xmlr.Element('type', str),
+    xmlr.AggregateElement('joint', TransmissionJoint),
+    xmlr.AggregateElement('actuator', Actuator)
+])
+
+xmlr.add_type('transmission',
+              xmlr.DuckTypedFactory('transmission',
+                                    [Transmission, PR2Transmission]))
+
 
 class Robot(xmlr.Object):
-	def __init__(self, name = None):
-		self.aggregate_init()
-		
-		self.name = name
-		self.joints = []
-		self.links = []
-		self.materials = []
-		self.gazebos = []
-		self.transmissions = []
-		
-		self.joint_map = {}
-		self.link_map = {}
+    def __init__(self, name=None):
+        self.aggregate_init()
 
-		self.parent_map = {}
-		self.child_map = {}
-	
-	def add_aggregate(self, typeName, elem):
-		xmlr.Object.add_aggregate(self, typeName, elem)
-		
-		if typeName == 'joint':
-			joint = elem
-			self.joint_map[joint.name] = joint
-			self.parent_map[ joint.child ] = (joint.name, joint.parent)
-			if joint.parent in self.child_map:
-				self.child_map[joint.parent].append( (joint.name, joint.child) )
-			else:
-				self.child_map[joint.parent] = [ (joint.name, joint.child) ]
-		elif typeName == 'link':
-			link = elem
-			self.link_map[link.name] = link
+        self.name = name
+        self.joints = []
+        self.links = []
+        self.materials = []
+        self.gazebos = []
+        self.transmissions = []
 
-	def add_link(self, link):
-		self.add_aggregate('link', link)
+        self.joint_map = {}
+        self.link_map = {}
 
-	def add_joint(self, joint):
-		self.add_aggregate('joint', joint)
+        self.parent_map = {}
+        self.child_map = {}
 
-	def get_chain(self, root, tip, joints=True, links=True, fixed=True):
-		chain = []
-		if links:
-			chain.append(tip)
-		link = tip
-		while link != root:
-			(joint, parent) = self.parent_map[link]
-			if joints:
-				if fixed or self.joint_map[joint].joint_type != 'fixed':
-					chain.append(joint)
-			if links:
-				chain.append(parent)
-			link = parent
-		chain.reverse()
-		return chain
+    def add_aggregate(self, typeName, elem):
+        xmlr.Object.add_aggregate(self, typeName, elem)
 
-	def get_root(self):
-		root = None
-		for link in self.link_map:
-			if link not in self.parent_map:
-				assert root is None, "Multiple roots detected, invalid URDF."
-				root = link
-		assert root is not None, "No roots detected, invalid URDF."
-		return root
+        if typeName == 'joint':
+            joint = elem
+            self.joint_map[joint.name] = joint
+            self.parent_map[joint.child] = (joint.name, joint.parent)
+            if joint.parent in self.child_map:
+                self.child_map[joint.parent].append((joint.name, joint.child))
+            else:
+                self.child_map[joint.parent] = [(joint.name, joint.child)]
+        elif typeName == 'link':
+            link = elem
+            self.link_map[link.name] = link
 
-	@classmethod
-	def from_parameter_server(cls, key = 'robot_description'):
-		"""
-		Retrieve the robot model on the parameter server
-		and parse it to create a URDF robot structure.
+    def add_link(self, link):
+        self.add_aggregate('link', link)
 
-		Warning: this requires roscore to be running.
-		"""
-		# Could move this into xml_reflection
-		import rospy
-		return cls.from_xml_string(rospy.get_param(key))
-	
-xmlr.reflect(Robot, tag = 'robot', params = [
-	xmlr.Attribute('name', str, False), # Is 'name' a required attribute?
-	xmlr.AggregateElement('link', Link),
-	xmlr.AggregateElement('joint', Joint),
-	xmlr.AggregateElement('gazebo', xmlr.RawType()),
-	xmlr.AggregateElement('transmission', 'transmission'),
-	xmlr.AggregateElement('material', Material)
-	])
+    def add_joint(self, joint):
+        self.add_aggregate('joint', joint)
+
+    def get_chain(self, root, tip, joints=True, links=True, fixed=True):
+        chain = []
+        if links:
+            chain.append(tip)
+        link = tip
+        while link != root:
+            (joint, parent) = self.parent_map[link]
+            if joints:
+                if fixed or self.joint_map[joint].joint_type != 'fixed':
+                    chain.append(joint)
+            if links:
+                chain.append(parent)
+            link = parent
+        chain.reverse()
+        return chain
+
+    def get_root(self):
+        root = None
+        for link in self.link_map:
+            if link not in self.parent_map:
+                assert root is None, "Multiple roots detected, invalid URDF."
+                root = link
+        assert root is not None, "No roots detected, invalid URDF."
+        return root
+
+    @classmethod
+    def from_parameter_server(cls, key='robot_description'):
+        """
+        Retrieve the robot model on the parameter server
+        and parse it to create a URDF robot structure.
+
+        Warning: this requires roscore to be running.
+        """
+        # Could move this into xml_reflection
+        import rospy
+        return cls.from_xml_string(rospy.get_param(key))
+
+
+xmlr.reflect(Robot, tag='robot', params=[
+    xmlr.Attribute('name', str, False),  # Is 'name' a required attribute?
+    xmlr.AggregateElement('link', Link),
+    xmlr.AggregateElement('joint', Joint),
+    xmlr.AggregateElement('gazebo', xmlr.RawType()),
+    xmlr.AggregateElement('transmission', 'transmission'),
+    xmlr.AggregateElement('material', Material)
+])
 
 # Make an alias
 URDF = Robot

--- a/src/urdf_parser_py/xml_reflection/basics.py
+++ b/src/urdf_parser_py/xml_reflection/basics.py
@@ -7,15 +7,18 @@ from lxml import etree
 # @todo Do not use this?
 from xml.etree.ElementTree import ElementTree
 
-def xml_string(rootXml, addHeader = True):
+
+def xml_string(rootXml, addHeader=True):
     # Meh
-    xmlString = etree.tostring(rootXml, pretty_print = True)
+    xmlString = etree.tostring(rootXml, pretty_print=True)
     if addHeader:
         xmlString = '<?xml version="1.0"?>\n' + xmlString
     return xmlString
 
+
 def dict_sub(obj, keys):
     return dict((key, obj[key]) for key in keys)
+
 
 def node_add(doc, sub):
     if sub is None:
@@ -23,19 +26,23 @@ def node_add(doc, sub):
     if type(sub) == str:
         return etree.SubElement(doc, sub)
     elif isinstance(sub, etree._Element):
-        doc.append(sub) # This screws up the rest of the tree for prettyprint...
+        doc.append(sub)  # This screws up the rest of the tree for prettyprint
         return sub
     else:
         raise Exception('Invalid sub value')
 
+
 def pfloat(x):
-    return str(x).rstrip('.') 
+    return str(x).rstrip('.')
+
 
 def xml_children(node):
     children = node.getchildren()
+
     def predicate(node):
         return not isinstance(node, etree._Comment)
     return list(filter(predicate, children))
+
 
 def isstring(obj):
     try:
@@ -43,9 +50,11 @@ def isstring(obj):
     except NameError:
         return isinstance(obj, str)
 
+
 def to_yaml(obj):
     """ Simplify yaml representation for pretty printing """
-    # Is there a better way to do this by adding a representation with yaml.Dumper?
+    # Is there a better way to do this by adding a representation with
+    # yaml.Dumper?
     # Ordered dict: http://pyyaml.org/ticket/29#comment:11
     if obj is None or isstring(obj):
         out = str(obj)
@@ -54,7 +63,7 @@ def to_yaml(obj):
     elif hasattr(obj, 'to_yaml'):
         out = obj.to_yaml()
     elif isinstance(obj, etree._Element):
-    	out = etree.tostring(obj, pretty_print = True)
+        out = etree.tostring(obj, pretty_print=True)
     elif type(obj) == dict:
         out = {}
         for (var, value) in obj.items():
@@ -68,14 +77,17 @@ def to_yaml(obj):
         out = str(obj)
     return out
 
+
 class SelectiveReflection(object):
-	def get_refl_vars(self):
-		return list(vars(self).keys())
+    def get_refl_vars(self):
+        return list(vars(self).keys())
+
 
 class YamlReflection(SelectiveReflection):
-	def to_yaml(self):
-		raw = dict((var, getattr(self, var)) for var in self.get_refl_vars())
-		return to_yaml(raw)
-		
-	def __str__(self):
-		return yaml.dump(self.to_yaml()).rstrip() # Good idea? Will it remove other important things?
+    def to_yaml(self):
+        raw = dict((var, getattr(self, var)) for var in self.get_refl_vars())
+        return to_yaml(raw)
+
+    def __str__(self):
+        # Good idea? Will it remove other important things?
+        return yaml.dump(self.to_yaml()).rstrip()

--- a/src/urdf_parser_py/xml_reflection/core.py
+++ b/src/urdf_parser_py/xml_reflection/core.py
@@ -9,531 +9,586 @@ import copy
 # Rename?
 
 # Do parent operations after, to allow child to 'override' parameters?
-	# Need to make sure that duplicate entires do not get into the 'unset*' lists
+# Need to make sure that duplicate entires do not get into the 'unset*' lists
+
 
 def reflect(cls, *args, **kwargs):
-	""" Simple wrapper to add XML reflection to an xml_reflection.Object class """
-	cls.XML_REFL = Reflection(*args, **kwargs)
+    """
+    Simple wrapper to add XML reflection to an xml_reflection.Object class
+    """
+    cls.XML_REFL = Reflection(*args, **kwargs)
 
-# Rename 'write_xml' to 'write_xml' to have paired 'load/dump', and make 'pre_dump' and 'post_load'?
+# Rename 'write_xml' to 'write_xml' to have paired 'load/dump', and make
+# 'pre_dump' and 'post_load'?
 # When dumping to yaml, include tag name?
 
 # How to incorporate line number and all that jazz?
+
+
 def on_error(message):
-	""" What to do on an error. This can be changed to raise an exception. """
-	sys.stderr.write(message + '\n')
+    """ What to do on an error. This can be changed to raise an exception. """
+    sys.stderr.write(message + '\n')
+
 
 skip_default = False
-#defaultIfMatching = True # Not implemeneted yet
+# defaultIfMatching = True # Not implemeneted yet
 
 # Registering Types
 value_types = {}
-value_type_prefix = '' 
+value_type_prefix = ''
+
 
 def start_namespace(namespace):
-	"""
-	Basic mechanism to prevent conflicts for string types for URDF and SDF
-	@note Does not handle nesting!
-	"""
-	global value_type_prefix
-	value_type_prefix = namespace + '.'
+    """
+    Basic mechanism to prevent conflicts for string types for URDF and SDF
+    @note Does not handle nesting!
+    """
+    global value_type_prefix
+    value_type_prefix = namespace + '.'
+
 
 def end_namespace():
-	global value_type_prefix
-	value_type_prefix = ''
+    global value_type_prefix
+    value_type_prefix = ''
+
 
 def add_type(key, value):
-	if isinstance(key, str):
-		key = value_type_prefix + key
-	assert key not in value_types
-	value_types[key] = value
+    if isinstance(key, str):
+        key = value_type_prefix + key
+    assert key not in value_types
+    value_types[key] = value
+
 
 def get_type(cur_type):
-	""" Can wrap value types if needed """
-	if value_type_prefix and isinstance(cur_type, str):
-		# See if it exists in current 'namespace'
-		curKey = value_type_prefix + cur_type
-		value_type = value_types.get(curKey)
-	else:
-		value_type = None
-	if value_type is None:
-		# Try again, in 'global' scope
-		value_type = value_types.get(cur_type)
-	if value_type is None:
-		value_type = make_type(cur_type)
-		add_type(cur_type, value_type)
-	return value_type
+    """ Can wrap value types if needed """
+    if value_type_prefix and isinstance(cur_type, str):
+        # See if it exists in current 'namespace'
+        curKey = value_type_prefix + cur_type
+        value_type = value_types.get(curKey)
+    else:
+        value_type = None
+    if value_type is None:
+        # Try again, in 'global' scope
+        value_type = value_types.get(cur_type)
+    if value_type is None:
+        value_type = make_type(cur_type)
+        add_type(cur_type, value_type)
+    return value_type
+
 
 def make_type(cur_type):
-	if isinstance(cur_type, ValueType):
-		return cur_type
-	elif isinstance(cur_type, str):
-		if cur_type.startswith('vector'):
-			extra = cur_type[6:]
-			if extra:
-				count = float(extra)
-			else:
-				count = None
-			return VectorType(count)
-		else:
-			raise Exception("Invalid value type: {}".format(cur_type))
-	elif cur_type == list:
-		return ListType()
-	elif issubclass(cur_type, Object):
-		return ObjectType(cur_type)
-	elif cur_type in [str, float]:
-		return BasicType(cur_type)
-	else:
-		raise Exception("Invalid type: {}".format(cur_type))
+    if isinstance(cur_type, ValueType):
+        return cur_type
+    elif isinstance(cur_type, str):
+        if cur_type.startswith('vector'):
+            extra = cur_type[6:]
+            if extra:
+                count = float(extra)
+            else:
+                count = None
+            return VectorType(count)
+        else:
+            raise Exception("Invalid value type: {}".format(cur_type))
+    elif cur_type == list:
+        return ListType()
+    elif issubclass(cur_type, Object):
+        return ObjectType(cur_type)
+    elif cur_type in [str, float]:
+        return BasicType(cur_type)
+    else:
+        raise Exception("Invalid type: {}".format(cur_type))
+
 
 class ValueType(object):
-	""" Primitive value type """
-	def from_xml(self, node):
-		return self.from_string(node.text)
-	
-	def write_xml(self, node, value):
-		""" If type has 'write_xml', this function should expect to have it's own XML already created
-		i.e., In Axis.to_sdf(self, node), 'node' would be the 'axis' element.
-		@todo Add function that makes an XML node completely independently?"""
-		node.text = self.to_string(value)
-	
-	def equals(self, a, b):
-		return a == b
+    """ Primitive value type """
+
+    def from_xml(self, node):
+        return self.from_string(node.text)
+
+    def write_xml(self, node, value):
+        """
+        If type has 'write_xml', this function should expect to have it's own
+        XML already created i.e., In Axis.to_sdf(self, node), 'node' would be
+        the 'axis' element.
+        @todo Add function that makes an XML node completely independently?
+        """
+        node.text = self.to_string(value)
+
+    def equals(self, a, b):
+        return a == b
+
 
 class BasicType(ValueType):
-	def __init__(self, cur_type):
-		self.type = cur_type
-	def to_string(self, value):
-		return str(value)
-	def from_string(self, value):
-		return self.type(value)
+    def __init__(self, cur_type):
+        self.type = cur_type
+
+    def to_string(self, value):
+        return str(value)
+
+    def from_string(self, value):
+        return self.type(value)
+
 
 class ListType(ValueType):
-	def to_string(self, values):
-		return ' '.join(values)
-	def from_string(self, text):
-		return text.split()
-	def equals(self, aValues, bValues):
-		return len(aValues) == len(bValues) and all(a == b for (a, b) in zip(aValues, bValues))
+    def to_string(self, values):
+        return ' '.join(values)
+
+    def from_string(self, text):
+        return text.split()
+
+    def equals(self, aValues, bValues):
+        return len(aValues) == len(bValues) and all(a == b for (a, b) in zip(aValues, bValues))  # noqa
+
 
 class VectorType(ListType):
-	def __init__(self, count = None):
-		self.count = count
-	
-	def check(self, values):
-		if self.count is not None:
-			assert len(values) == self.count, "Invalid vector length"
-	
-	def to_string(self, values):
-		self.check(values)
-		raw = list(map(str, values))
-		return ListType.to_string(self, raw)
-		
-	def from_string(self, text):
-		raw = ListType.from_string(self, text)
-		self.check(raw)
-		return list(map(float, raw))
+    def __init__(self, count=None):
+        self.count = count
+
+    def check(self, values):
+        if self.count is not None:
+            assert len(values) == self.count, "Invalid vector length"
+
+    def to_string(self, values):
+        self.check(values)
+        raw = list(map(str, values))
+        return ListType.to_string(self, raw)
+
+    def from_string(self, text):
+        raw = ListType.from_string(self, text)
+        self.check(raw)
+        return list(map(float, raw))
+
 
 class RawType(ValueType):
-	""" Simple, raw XML value. Need to bugfix putting this back into a document """
-	def from_xml(self, node):
-		return node
-	
-	def write_xml(self, node, value):
-		# @todo rying to insert an element at root level seems to screw up pretty printing
-		children = xml_children(value)
-		list(map(node.append, children))
-		# Copy attributes
-		for (attrib_key, attrib_value) in value.attrib.iteritems():
-			node.set(attrib_key, attrib_value)
+    """
+    Simple, raw XML value. Need to bugfix putting this back into a document
+    """
+
+    def from_xml(self, node):
+        return node
+
+    def write_xml(self, node, value):
+        # @todo rying to insert an element at root level seems to screw up
+        # pretty printing
+        children = xml_children(value)
+        list(map(node.append, children))
+        # Copy attributes
+        for (attrib_key, attrib_value) in value.attrib.iteritems():
+            node.set(attrib_key, attrib_value)
+
 
 class SimpleElementType(ValueType):
-	"""
-	Extractor that retrieves data from an element, given a
-	specified attribute, casted to value_type.
-	"""
-	def __init__(self, attribute, value_type):
-		self.attribute = attribute
-		self.value_type = get_type(value_type)
-	def from_xml(self, node):
-		text = node.get(self.attribute)
-		return self.value_type.from_string(text)
-	def write_xml(self, node, value):
-		text = self.value_type.to_string(value)
-		node.set(self.attribute, text)
+    """
+    Extractor that retrieves data from an element, given a
+    specified attribute, casted to value_type.
+    """
+
+    def __init__(self, attribute, value_type):
+        self.attribute = attribute
+        self.value_type = get_type(value_type)
+
+    def from_xml(self, node):
+        text = node.get(self.attribute)
+        return self.value_type.from_string(text)
+
+    def write_xml(self, node, value):
+        text = self.value_type.to_string(value)
+        node.set(self.attribute, text)
+
 
 class ObjectType(ValueType):
-	def __init__(self, cur_type):
-		self.type = cur_type
-		
-	def from_xml(self, node):
-		obj = self.type()
-		obj.read_xml(node)
-		return obj
-	
-	def write_xml(self, node, obj):
-		obj.write_xml(node)
+    def __init__(self, cur_type):
+        self.type = cur_type
+
+    def from_xml(self, node):
+        obj = self.type()
+        obj.read_xml(node)
+        return obj
+
+    def write_xml(self, node, obj):
+        obj.write_xml(node)
+
 
 class FactoryType(ValueType):
-	def __init__(self, name, typeMap):
-		self.name = name
-		self.typeMap = typeMap
-		self.nameMap = {}
-		for (key, value) in typeMap.items():
-			# Reverse lookup
-			self.nameMap[value] = key
-	
-	def from_xml(self, node):
-		cur_type = self.typeMap.get(node.tag)
-		if cur_type is None:
-			raise Exception("Invalid {} tag: {}".format(self.name, node.tag))
-		value_type = get_type(cur_type)
-		return value_type.from_xml(node)
-	
-	def get_name(self, obj):
-		cur_type = type(obj)
-		name = self.nameMap.get(cur_type)
-		if name is None:
-			raise Exception("Invalid {} type: {}".format(self.name, cur_type))
-		return name
-	
-	def write_xml(self, node, obj):
-		obj.write_xml(node)
+    def __init__(self, name, typeMap):
+        self.name = name
+        self.typeMap = typeMap
+        self.nameMap = {}
+        for (key, value) in typeMap.items():
+            # Reverse lookup
+            self.nameMap[value] = key
+
+    def from_xml(self, node):
+        cur_type = self.typeMap.get(node.tag)
+        if cur_type is None:
+            raise Exception("Invalid {} tag: {}".format(self.name, node.tag))
+        value_type = get_type(cur_type)
+        return value_type.from_xml(node)
+
+    def get_name(self, obj):
+        cur_type = type(obj)
+        name = self.nameMap.get(cur_type)
+        if name is None:
+            raise Exception("Invalid {} type: {}".format(self.name, cur_type))
+        return name
+
+    def write_xml(self, node, obj):
+        obj.write_xml(node)
+
 
 class DuckTypedFactory(ValueType):
-	def __init__(self, name, typeOrder):
-		self.name = name
-		assert len(typeOrder) > 0
-		self.type_order = typeOrder
-	
-	def from_xml(self, node):
-		error_set = []
-		for value_type in self.type_order:
-			try:
-				return value_type.from_xml(node)
-			except Exception as e:
-				error_set.append((value_type, e))
-		# Should have returned, we encountered errors
-		out = "Could not perform duck-typed parsing."
-		for (value_type, e) in error_set:
-			out += "\nValue Type: {}\nException: {}\n".format(value_type, e)
-		raise Exception(out)
-	
-	def write_xml(self, node, obj):
-		obj.write_xml(node)
+    def __init__(self, name, typeOrder):
+        self.name = name
+        assert len(typeOrder) > 0
+        self.type_order = typeOrder
+
+    def from_xml(self, node):
+        error_set = []
+        for value_type in self.type_order:
+            try:
+                return value_type.from_xml(node)
+            except Exception as e:
+                error_set.append((value_type, e))
+        # Should have returned, we encountered errors
+        out = "Could not perform duck-typed parsing."
+        for (value_type, e) in error_set:
+            out += "\nValue Type: {}\nException: {}\n".format(value_type, e)
+        raise Exception(out)
+
+    def write_xml(self, node, obj):
+        obj.write_xml(node)
+
 
 class Param(object):
-	""" Mirroring Gazebo's SDF api
-	
-	@param xml_var: Xml name
-		@todo If the value_type is an object with a tag defined in it's reflection, allow it to act as the default tag name?
-	@param var: Python class variable name. By default it's the same as the XML name
-	"""
-	def __init__(self, xml_var, value_type, required = True, default = None, var = None):
-		self.xml_var = xml_var
-		if var is None:
-			self.var = xml_var
-		else:
-			self.var = var
-		self.type = None
-		self.value_type = get_type(value_type)
-		self.default = default
-		if required:
-			assert default is None, "Default does not make sense for a required field"
-		self.required = required
-		self.is_aggregate = False
-	
-	def set_default(self, obj):
-		if self.required:
-			raise Exception("Required {} not set in XML: {}".format(self.type, self.xml_var))
-		elif not skip_default:
-			setattr(obj, self.var, self.default)
+    """ Mirroring Gazebo's SDF api
+
+    @param xml_var: Xml name
+            @todo If the value_type is an object with a tag defined in it's
+                  reflection, allow it to act as the default tag name?
+    @param var: Python class variable name. By default it's the same as the
+                XML name
+    """
+
+    def __init__(self, xml_var, value_type, required=True, default=None,
+                 var=None):
+        self.xml_var = xml_var
+        if var is None:
+            self.var = xml_var
+        else:
+            self.var = var
+        self.type = None
+        self.value_type = get_type(value_type)
+        self.default = default
+        if required:
+            assert default is None, "Default does not make sense for a required field"  # noqa
+        self.required = required
+        self.is_aggregate = False
+
+    def set_default(self, obj):
+        if self.required:
+            raise Exception("Required {} not set in XML: {}".format(self.type, self.xml_var))  # noqa
+        elif not skip_default:
+            setattr(obj, self.var, self.default)
+
 
 class Attribute(Param):
-	def __init__(self, xml_var, value_type, required = True, default = None, var = None):
-		Param.__init__(self, xml_var, value_type, required, default, var)
-		self.type = 'attribute'
-	
-	def set_from_string(self, obj, value):
-		""" Node is the parent node in this case """
-		# Duplicate attributes cannot occur at this point
-		setattr(obj, self.var, self.value_type.from_string(value))
-		
-	def add_to_xml(self, obj, node):
-		value = getattr(obj, self.var)
-		# Do not set with default value if value is None
-		if value is None:
-			if self.required:
-				raise Exception("Required attribute not set in object: {}".format(self.var))
-			elif not skip_default:
-				value = self.default
-		# Allow value type to handle None?
-		if value is not None:
-			node.set(self.xml_var, self.value_type.to_string(value))
+    def __init__(self, xml_var, value_type, required=True, default=None,
+                 var=None):
+        Param.__init__(self, xml_var, value_type, required, default, var)
+        self.type = 'attribute'
 
-# Add option if this requires a header? Like <joints> <joint/> .... </joints> ??? Not really... This would be a specific list type, not really aggregate
+    def set_from_string(self, obj, value):
+        """ Node is the parent node in this case """
+        # Duplicate attributes cannot occur at this point
+        setattr(obj, self.var, self.value_type.from_string(value))
+
+    def add_to_xml(self, obj, node):
+        value = getattr(obj, self.var)
+        # Do not set with default value if value is None
+        if value is None:
+            if self.required:
+                raise Exception("Required attribute not set in object: {}".format(self.var))  # noqa
+            elif not skip_default:
+                value = self.default
+        # Allow value type to handle None?
+        if value is not None:
+            node.set(self.xml_var, self.value_type.to_string(value))
+
+# Add option if this requires a header?
+# Like <joints> <joint/> .... </joints> ???
+# Not really... This would be a specific list type, not really aggregate
+
 
 class Element(Param):
-	def __init__(self, xml_var, value_type, required = True, default = None, var = None, is_raw = False):
-		Param.__init__(self, xml_var, value_type, required, default, var)
-		self.type = 'element'
-		self.is_raw = is_raw
-		
-	def set_from_xml(self, obj, node):
-		value = self.value_type.from_xml(node)
-		setattr(obj, self.var, value)
-	
-	def add_to_xml(self, obj, parent):
-		value = getattr(obj, self.xml_var)
-		if value is None:
-			if self.required:
-				raise Exception("Required element not defined in object: {}".format(self.var))
-			elif not skip_default:
-				value = self.default
-		if value is not None:
-			self.add_scalar_to_xml(parent, value)
-	
-	def add_scalar_to_xml(self, parent, value):
-		if self.is_raw:
-			node = parent
-		else:
-			node = node_add(parent, self.xml_var)
-		self.value_type.write_xml(node, value)
+    def __init__(self, xml_var, value_type, required=True, default=None,
+                 var=None, is_raw=False):
+        Param.__init__(self, xml_var, value_type, required, default, var)
+        self.type = 'element'
+        self.is_raw = is_raw
+
+    def set_from_xml(self, obj, node):
+        value = self.value_type.from_xml(node)
+        setattr(obj, self.var, value)
+
+    def add_to_xml(self, obj, parent):
+        value = getattr(obj, self.xml_var)
+        if value is None:
+            if self.required:
+                raise Exception("Required element not defined in object: {}".format(self.var))  # noqa
+            elif not skip_default:
+                value = self.default
+        if value is not None:
+            self.add_scalar_to_xml(parent, value)
+
+    def add_scalar_to_xml(self, parent, value):
+        if self.is_raw:
+            node = parent
+        else:
+            node = node_add(parent, self.xml_var)
+        self.value_type.write_xml(node, value)
 
 
 class AggregateElement(Element):
-	def __init__(self, xml_var, value_type, var = None, is_raw = False):
-		if var is None:
-			var = xml_var + 's'
-		Element.__init__(self, xml_var, value_type, required = False, var = var, is_raw = is_raw)
-		self.is_aggregate = True
-		
-	def add_from_xml(self, obj, node):
-		value = self.value_type.from_xml(node)
-		obj.add_aggregate(self.xml_var, value)
-	
-	def set_default(self, obj):
-		pass
-	
+    def __init__(self, xml_var, value_type, var=None, is_raw=False):
+        if var is None:
+            var = xml_var + 's'
+        Element.__init__(self, xml_var, value_type, required=False, var=var,
+                         is_raw=is_raw)
+        self.is_aggregate = True
+
+    def add_from_xml(self, obj, node):
+        value = self.value_type.from_xml(node)
+        obj.add_aggregate(self.xml_var, value)
+
+    def set_default(self, obj):
+        pass
+
 
 class Info:
-	""" Small container for keeping track of what's been consumed """
-	def __init__(self, node):
-		self.attributes = list(node.attrib.keys())
-		self.children = xml_children(node)
+    """ Small container for keeping track of what's been consumed """
+
+    def __init__(self, node):
+        self.attributes = list(node.attrib.keys())
+        self.children = xml_children(node)
+
 
 class Reflection(object):
-	def __init__(self, params = [], parent_cls = None, tag = None):
-		""" Construct a XML reflection thing
-		@param parent_cls: Parent class, to use it's reflection as well.
-		@param tag: Only necessary if you intend to use Object.write_xml_doc()
-			This does not override the name supplied in the reflection definition thing.
-		"""
-		if parent_cls is not None:
-			self.parent = parent_cls.XML_REFL
-		else:
-			self.parent = None
-		self.tag = tag
-		
-		# Laziness for now
-		attributes = []
-		elements = []
-		for param in params:
-			if isinstance(param, Element):
-				elements.append(param)
-			else:
-				attributes.append(param)
-		
-		self.vars = []
-		self.paramMap = {}
-		
-		self.attributes = attributes
-		self.attribute_map = {}
-		self.required_attribute_names = []
-		for attribute in attributes:
-			self.attribute_map[attribute.xml_var] = attribute
-			self.paramMap[attribute.xml_var] = attribute
-			self.vars.append(attribute.var)
-			if attribute.required:
-				self.required_attribute_names.append(attribute.xml_var)
-		
-		self.elements = []
-		self.element_map = {}
-		self.required_element_names = []
-		self.aggregates = []
-		self.scalars = []
-		self.scalarNames = []
-		for element in elements:
-			self.element_map[element.xml_var] = element
-			self.paramMap[element.xml_var] = element
-			self.vars.append(element.var)
-			if element.required:
-				self.required_element_names.append(element.xml_var)
-			if element.is_aggregate:
-				self.aggregates.append(element)
-			else:
-				self.scalars.append(element)
-				self.scalarNames.append(element.xml_var)
-	
-	def set_from_xml(self, obj, node, info = None):
-		is_final = False
-		if info is None:
-			is_final = True
-			info = Info(node)
-		
-		if self.parent:
-			self.parent.set_from_xml(obj, node, info)
-		
-		# Make this a map instead? Faster access? {name: isSet} ?
-		unset_attributes = list(self.attribute_map.keys())
-		unset_scalars = copy.copy(self.scalarNames)
-		# Better method? Queues?
-		for xml_var in copy.copy(info.attributes):
-			attribute = self.attribute_map.get(xml_var)
-			if attribute is not None:
-				value = node.attrib[xml_var]
-				attribute.set_from_string(obj, value)
-				unset_attributes.remove(xml_var)
-				info.attributes.remove(xml_var)
-		
-		# Parse unconsumed nodes
-		for child in copy.copy(info.children):
-			tag = child.tag
-			element = self.element_map.get(tag)
-			if element is not None:
-				if element.is_aggregate:
-					element.add_from_xml(obj, child)
-				else:
-					if tag in unset_scalars:
-						element.set_from_xml(obj, child)
-						unset_scalars.remove(tag)
-					else:
-						on_error("Scalar element defined multiple times: {}".format(tag))
-				info.children.remove(child)
-		
-		for attribute in map(self.attribute_map.get, unset_attributes):
-			attribute.set_default(obj)
-			
-		for element in map(self.element_map.get, unset_scalars):
-			element.set_default(obj)
-		
-		if is_final:
-			for xml_var in info.attributes:
-				on_error('Unknown attribute: {}'.format(xml_var))
-			for node in info.children:
-				on_error('Unknown tag: {}'.format(node.tag))
-	
-	def add_to_xml(self, obj, node):
-		if self.parent:
-			self.parent.add_to_xml(obj, node)
-		for attribute in self.attributes:
-			attribute.add_to_xml(obj, node)
-		for element in self.scalars:
-			element.add_to_xml(obj, node)
-		# Now add in aggregates
-		if self.aggregates:
-			obj.add_aggregates_to_xml(node)
+    def __init__(self, params=[], parent_cls=None, tag=None):
+        """ Construct a XML reflection thing
+        @param parent_cls: Parent class, to use it's reflection as well.
+        @param tag: Only necessary if you intend to use Object.write_xml_doc()
+                This does not override the name supplied in the reflection
+                definition thing.
+        """
+        if parent_cls is not None:
+            self.parent = parent_cls.XML_REFL
+        else:
+            self.parent = None
+        self.tag = tag
+
+        # Laziness for now
+        attributes = []
+        elements = []
+        for param in params:
+            if isinstance(param, Element):
+                elements.append(param)
+            else:
+                attributes.append(param)
+
+        self.vars = []
+        self.paramMap = {}
+
+        self.attributes = attributes
+        self.attribute_map = {}
+        self.required_attribute_names = []
+        for attribute in attributes:
+            self.attribute_map[attribute.xml_var] = attribute
+            self.paramMap[attribute.xml_var] = attribute
+            self.vars.append(attribute.var)
+            if attribute.required:
+                self.required_attribute_names.append(attribute.xml_var)
+
+        self.elements = []
+        self.element_map = {}
+        self.required_element_names = []
+        self.aggregates = []
+        self.scalars = []
+        self.scalarNames = []
+        for element in elements:
+            self.element_map[element.xml_var] = element
+            self.paramMap[element.xml_var] = element
+            self.vars.append(element.var)
+            if element.required:
+                self.required_element_names.append(element.xml_var)
+            if element.is_aggregate:
+                self.aggregates.append(element)
+            else:
+                self.scalars.append(element)
+                self.scalarNames.append(element.xml_var)
+
+    def set_from_xml(self, obj, node, info=None):
+        is_final = False
+        if info is None:
+            is_final = True
+            info = Info(node)
+
+        if self.parent:
+            self.parent.set_from_xml(obj, node, info)
+
+        # Make this a map instead? Faster access? {name: isSet} ?
+        unset_attributes = list(self.attribute_map.keys())
+        unset_scalars = copy.copy(self.scalarNames)
+        # Better method? Queues?
+        for xml_var in copy.copy(info.attributes):
+            attribute = self.attribute_map.get(xml_var)
+            if attribute is not None:
+                value = node.attrib[xml_var]
+                attribute.set_from_string(obj, value)
+                unset_attributes.remove(xml_var)
+                info.attributes.remove(xml_var)
+
+        # Parse unconsumed nodes
+        for child in copy.copy(info.children):
+            tag = child.tag
+            element = self.element_map.get(tag)
+            if element is not None:
+                if element.is_aggregate:
+                    element.add_from_xml(obj, child)
+                else:
+                    if tag in unset_scalars:
+                        element.set_from_xml(obj, child)
+                        unset_scalars.remove(tag)
+                    else:
+                        on_error("Scalar element defined multiple times: {}".format(tag))  # noqa
+                info.children.remove(child)
+
+        for attribute in map(self.attribute_map.get, unset_attributes):
+            attribute.set_default(obj)
+
+        for element in map(self.element_map.get, unset_scalars):
+            element.set_default(obj)
+
+        if is_final:
+            for xml_var in info.attributes:
+                on_error('Unknown attribute: {}'.format(xml_var))
+            for node in info.children:
+                on_error('Unknown tag: {}'.format(node.tag))
+
+    def add_to_xml(self, obj, node):
+        if self.parent:
+            self.parent.add_to_xml(obj, node)
+        for attribute in self.attributes:
+            attribute.add_to_xml(obj, node)
+        for element in self.scalars:
+            element.add_to_xml(obj, node)
+        # Now add in aggregates
+        if self.aggregates:
+            obj.add_aggregates_to_xml(node)
+
 
 class Object(YamlReflection):
-	""" Raw python object for yaml / xml representation """
-	XML_REFL = None
-	
-	def get_refl_vars(self):
-		return self.XML_REFL.vars
-	
-	def check_valid(self):
-		pass
-	
-	def pre_write_xml(self):
-		""" If anything needs to be converted prior to dumping to xml
-		i.e., getting the names of objects and such """
-		pass
-	
-	def write_xml(self, node):
-		""" Adds contents directly to XML node """
-		self.check_valid()
-		self.pre_write_xml()
-		self.XML_REFL.add_to_xml(self, node)
-	
-	def to_xml(self):
-		""" Creates an overarching tag and adds its contents to the node """
-		tag = self.XML_REFL.tag
-		assert tag is not None, "Must define 'tag' in reflection to use this function"
-		doc = etree.Element(tag)
-		self.write_xml(doc)
-		return doc
-	
-	def to_xml_string(self, addHeader = True):
-		return xml_string(self.to_xml(), addHeader)
-	
-	def post_read_xml(self):
-		pass
-	
-	def read_xml(self, node):
-		self.XML_REFL.set_from_xml(self, node)
-		self.post_read_xml()
-		self.check_valid()
-		
-	@classmethod
-	def from_xml(cls, node):
-		cur_type = get_type(cls)
-		return cur_type.from_xml(node)
-	
-	@classmethod
-	def from_xml_string(cls, xml_string):
-		node = etree.fromstring(xml_string)
-		return cls.from_xml(node)
-	
-	@classmethod
-	def from_xml_file(cls, file_path):
-		xml_string= open(file_path, 'r').read()
-		return cls.from_xml_string(xml_string)
+    """ Raw python object for yaml / xml representation """
+    XML_REFL = None
 
-	# Confusing distinction between loading code in object and reflection registry thing...
+    def get_refl_vars(self):
+        return self.XML_REFL.vars
 
-	def get_aggregate_list(self, xml_var):
-		var = self.XML_REFL.paramMap[xml_var].var
-		values = getattr(self, var)
-		assert isinstance(values, list)
-		return values
-		
-	def aggregate_init(self):
-		""" Must be called in constructor! """
-		self.aggregate_order = []
-		# Store this info in the loaded object??? Nah
-		self.aggregate_type = {}
-		
-	def add_aggregate(self, xml_var, obj):
-		""" NOTE: One must keep careful track of aggregate types for this system.
-		Can use 'lump_aggregates()' before writing if you don't care. """
-		self.get_aggregate_list(xml_var).append(obj)
-		self.aggregate_order.append(obj)
-		self.aggregate_type[obj] = xml_var
-	
-	def add_aggregates_to_xml(self, node):
-		for value in self.aggregate_order:
-			typeName = self.aggregate_type[value]
-			element = self.XML_REFL.element_map[typeName]
-			element.add_scalar_to_xml(node, value)
-	
-	def remove_aggregate(self, obj):
-		self.aggregate_order.remove(obj)
-		xml_var = self.aggregate_type[obj]
-		del self.aggregate_type[obj]
-		self.get_aggregate_list(xml_var).remove(obj)
-	
-	def lump_aggregates(self):
-		""" Put all aggregate types together, just because """
-		self.aggregate_init()
-		for param in self.XML_REFL.aggregates:
-			for obj in self.get_aggregate_list(param.xml_var):
-				self.add_aggregate(param.var, obj)
-	
-	""" Compatibility """
-	def parse(self, xml_string):
-		node = etree.fromstring(xml_string)
-		self.read_xml(node)
-		return self
+    def check_valid(self):
+        pass
+
+    def pre_write_xml(self):
+        """ If anything needs to be converted prior to dumping to xml
+        i.e., getting the names of objects and such """
+        pass
+
+    def write_xml(self, node):
+        """ Adds contents directly to XML node """
+        self.check_valid()
+        self.pre_write_xml()
+        self.XML_REFL.add_to_xml(self, node)
+
+    def to_xml(self):
+        """ Creates an overarching tag and adds its contents to the node """
+        tag = self.XML_REFL.tag
+        assert tag is not None, "Must define 'tag' in reflection to use this function"  # noqa
+        doc = etree.Element(tag)
+        self.write_xml(doc)
+        return doc
+
+    def to_xml_string(self, addHeader=True):
+        return xml_string(self.to_xml(), addHeader)
+
+    def post_read_xml(self):
+        pass
+
+    def read_xml(self, node):
+        self.XML_REFL.set_from_xml(self, node)
+        self.post_read_xml()
+        self.check_valid()
+
+    @classmethod
+    def from_xml(cls, node):
+        cur_type = get_type(cls)
+        return cur_type.from_xml(node)
+
+    @classmethod
+    def from_xml_string(cls, xml_string):
+        node = etree.fromstring(xml_string)
+        return cls.from_xml(node)
+
+    @classmethod
+    def from_xml_file(cls, file_path):
+        xml_string = open(file_path, 'r').read()
+        return cls.from_xml_string(xml_string)
+
+    # Confusing distinction between loading code in object and reflection
+    # registry thing...
+
+    def get_aggregate_list(self, xml_var):
+        var = self.XML_REFL.paramMap[xml_var].var
+        values = getattr(self, var)
+        assert isinstance(values, list)
+        return values
+
+    def aggregate_init(self):
+        """ Must be called in constructor! """
+        self.aggregate_order = []
+        # Store this info in the loaded object??? Nah
+        self.aggregate_type = {}
+
+    def add_aggregate(self, xml_var, obj):
+        """ NOTE: One must keep careful track of aggregate types for this system.
+        Can use 'lump_aggregates()' before writing if you don't care. """
+        self.get_aggregate_list(xml_var).append(obj)
+        self.aggregate_order.append(obj)
+        self.aggregate_type[obj] = xml_var
+
+    def add_aggregates_to_xml(self, node):
+        for value in self.aggregate_order:
+            typeName = self.aggregate_type[value]
+            element = self.XML_REFL.element_map[typeName]
+            element.add_scalar_to_xml(node, value)
+
+    def remove_aggregate(self, obj):
+        self.aggregate_order.remove(obj)
+        xml_var = self.aggregate_type[obj]
+        del self.aggregate_type[obj]
+        self.get_aggregate_list(xml_var).remove(obj)
+
+    def lump_aggregates(self):
+        """ Put all aggregate types together, just because """
+        self.aggregate_init()
+        for param in self.XML_REFL.aggregates:
+            for obj in self.get_aggregate_list(param.xml_var):
+                self.add_aggregate(param.var, obj)
+
+    """ Compatibility """
+
+    def parse(self, xml_string):
+        node = etree.fromstring(xml_string)
+        self.read_xml(node)
+        return self
+
 
 # Really common types
 # Better name: element_with_name? Attributed element?

--- a/test/test_urdf.py
+++ b/test/test_urdf.py
@@ -7,14 +7,17 @@ import sys
 
 # Add path to import xml_matching
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '.')))
-sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '../src')))
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__),
+                                             '../src')))
 
-from xml.dom import minidom
-from xml_matching import xml_matches
-from urdf_parser_py import urdf
+from xml.dom import minidom  # noqa
+from xml_matching import xml_matches  # noqa
+from urdf_parser_py import urdf  # noqa
+
 
 class ParseException(Exception):
     pass
+
 
 class TestURDFParser(unittest.TestCase):
     @mock.patch('urdf_parser_py.xml_reflection.on_error',
@@ -175,8 +178,8 @@ class LinkOriginTestCase(unittest.TestCase):
         robot = self.parse(xml)
         origin = robot.links[0].inertial.origin
         self.assertEquals(origin.xyz, [1, 2, 3])
-        self.assertEquals(origin.rpy, [0 ,0, 0])
-    
+        self.assertEquals(origin.rpy, [0, 0, 0])
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/xml_matching.py
+++ b/test/xml_matching.py
@@ -5,26 +5,27 @@ import sys
 # regex to match whitespace
 whitespace = re.compile(r'\s+')
 
+
 def all_attributes_match(a, b):
     if len(a.attributes) != len(b.attributes):
         print("Different number of attributes")
         return False
-    a_atts = [(a.attributes.item(i).name, a.attributes.item(i).value) for i in range(len(a.attributes))]
-    b_atts = [(b.attributes.item(i).name, b.attributes.item(i).value) for i in range(len(b.attributes))]
+    a_atts = [(a.attributes.item(i).name, a.attributes.item(i).value) for i in range(len(a.attributes))]  # noqa
+    b_atts = [(b.attributes.item(i).name, b.attributes.item(i).value) for i in range(len(b.attributes))]  # noqa
     a_atts.sort()
     b_atts.sort()
 
     for i in range(len(a_atts)):
         if a_atts[i][0] != b_atts[i][0]:
-            print("Different attribute names: %s and %s" % (a_atts[i][0], b_atts[i][0]))
+            print("Different attribute names: %s and %s" % (a_atts[i][0], b_atts[i][0]))  # noqa
             return False
         try:
             if abs(float(a_atts[i][1]) - float(b_atts[i][1])) > 1.0e-9:
-                print("Different attribute values: %s and %s" % (a_atts[i][1], b_atts[i][1]))
+                print("Different attribute values: %s and %s" % (a_atts[i][1], b_atts[i][1]))  # noqa
                 return False
         except ValueError:  # Attribute values aren't numeric
             if a_atts[i][1] != b_atts[i][1]:
-                print("Different attribute values: %s and %s" % (a_atts[i][1], b_atts[i][1]))
+                print("Different attribute values: %s and %s" % (a_atts[i][1], b_atts[i][1]))  # noqa
                 return False
 
     return True
@@ -33,7 +34,8 @@ def all_attributes_match(a, b):
 def text_matches(a, b):
     a_norm = whitespace.sub(' ', a)
     b_norm = whitespace.sub(' ', b)
-    if a_norm.strip() == b_norm.strip(): return True
+    if a_norm.strip() == b_norm.strip():
+        return True
     print("Different text values: '%s' and '%s'" % (a, b))
     return False
 
@@ -73,27 +75,31 @@ def nodes_match(a, b, ignore_nodes):
         # we could have several text nodes in a row, due to replacements
         while (a and
                ((a.nodeType in ignore_nodes) or
-                (a.nodeType == xml.dom.Node.TEXT_NODE and whitespace.sub('', a.data) == ""))):
+                (a.nodeType == xml.dom.Node.TEXT_NODE and whitespace.sub('', a.data) == ""))):  # noqa
             a = a.nextSibling
         while (b and
                ((b.nodeType in ignore_nodes) or
-                (b.nodeType == xml.dom.Node.TEXT_NODE and whitespace.sub('', b.data) == ""))):
+                (b.nodeType == xml.dom.Node.TEXT_NODE and whitespace.sub('', b.data) == ""))):  # noqa
             b = b.nextSibling
 
         if not nodes_match(a, b, ignore_nodes):
             return False
 
-        if a: a = a.nextSibling
-        if b: b = b.nextSibling
+        if a:
+            a = a.nextSibling
+        if b:
+            b = b.nextSibling
 
     return True
 
 
 def xml_matches(a, b, ignore_nodes=[]):
     if isinstance(a, str):
-        return xml_matches(xml.dom.minidom.parseString(a).documentElement, b, ignore_nodes)
+        return xml_matches(xml.dom.minidom.parseString(a).documentElement, b,
+                           ignore_nodes)
     if isinstance(b, str):
-        return xml_matches(a, xml.dom.minidom.parseString(b).documentElement, ignore_nodes)
+        return xml_matches(a, xml.dom.minidom.parseString(b).documentElement,
+                           ignore_nodes)
     if a.nodeType == xml.dom.Node.DOCUMENT_NODE:
         return xml_matches(a.documentElement, b, ignore_nodes)
     if b.nodeType == xml.dom.Node.DOCUMENT_NODE:


### PR DESCRIPTION
clalancette also did some additional work here to bring it
all the way up to standard.

@willcbaker I split this out of your other patchset for #20, and made a few additional modifications to it.  Note that I removed some of the modifications that weren't strictly for pep8.  Once I merge this, you'll want to rebase #20 on top of this.