### PR TITLE
Add Link.visual and Link.collision properties

### DIFF
--- a/src/urdf_parser_py/urdf.py
+++ b/src/urdf_parser_py/urdf.py
@@ -359,6 +359,35 @@ class Link(xmlr.Object):
         self.collisions = []
         self.origin = origin
 
+    def __get_visual(self):
+        """Return the first visual or None."""
+        if self.visuals:
+            return self.visuals[0]
+
+    def __set_visual(self, visual):
+        """Set the first visual."""
+        if self.visuals:
+            self.visuals[0] = visual
+        else:
+            self.visuals.append(visual)
+
+    def __get_collision(self):
+        """Return the first collision or None."""
+        if self.collisions:
+            return self.collisions[0]
+
+    def __set_collision(self, collision):
+        """Set the first collision."""
+        if self.collisions:
+            self.collisions[0] = collision
+        else:
+            self.collisions.append(collision)
+
+    # Properties for backwards compatibility
+    visual = property(__get_visual, __set_visual)
+    collision = property(__get_collision, __set_collision)
+
+
 xmlr.reflect(Link, tag='link', params=[
     name_attribute,
     origin_element,

--- a/test/test_urdf.py
+++ b/test/test_urdf.py
@@ -220,5 +220,61 @@ class LinkOriginTestCase(unittest.TestCase):
         self.assertEquals(origin.rpy, [0, 0, 0])
 
 
+class LinkMultiVisualsAndCollisionsTest(unittest.TestCase):
+
+    xml = '''<?xml version="1.0"?>
+<robot name="test">
+  <link name="link">
+    <visual>
+      <geometry>
+        <cylinder length="1" radius="1"/>
+      </geometry>
+      <material name="mat"/>
+    </visual>
+    <visual>
+      <geometry>
+        <cylinder length="4" radius="0.5"/>
+      </geometry>
+      <material name="mat2"/>
+    </visual>
+    <collision>
+      <geometry>
+        <cylinder length="1" radius="1"/>
+      </geometry>
+    </collision>
+    <collision>
+      <geometry>
+        <cylinder length="4" radius="0.5"/>
+      </geometry>
+    </collision>
+  </link>
+  <link name="link2"/>
+</robot>'''
+
+    def test_multi_visual_access(self):
+        robot = urdf.Robot.from_xml_string(self.xml)
+        self.assertEquals(2, len(robot.links[0].visuals))
+        self.assertEqual(
+            id(robot.links[0].visuals[0]), id(robot.links[0].visual))
+
+        self.assertEquals(None, robot.links[1].visual)
+
+        dummyObject = set()
+        robot.links[0].visual = dummyObject
+        self.assertEquals(id(dummyObject), id(robot.links[0].visuals[0]))
+
+    def test_multi_collision_access(self):
+        robot = urdf.Robot.from_xml_string(self.xml)
+        self.assertEquals(2, len(robot.links[0].collisions))
+        self.assertEqual(
+            id(robot.links[0].collisions[0]), id(robot.links[0].collision))
+
+        self.assertEquals(None, robot.links[1].collision)
+
+        dummyObject = set()
+        robot.links[0].collision = dummyObject
+        self.assertEquals(id(dummyObject), id(robot.links[0].collisions[0]))
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This adds two properties `visual` and `collision` to the link class. The purpose is backwards compatibility after #26. The property accesses the first visual or collision on the link. 