### PR TITLE
Allow name attribute in visual tag

### DIFF
--- a/src/urdf_parser_py/urdf.py
+++ b/src/urdf_parser_py/urdf.py
@@ -194,7 +194,7 @@ class LinkMaterial(Material):
 
 
 class Visual(xmlr.Object):
-    def __init__(self, geometry=None, material=None, name=None, origin=None):
+    def __init__(self, geometry=None, material=None, origin=None, name=None):
         self.geometry = geometry
         self.material = material
         self.name = name

--- a/src/urdf_parser_py/urdf.py
+++ b/src/urdf_parser_py/urdf.py
@@ -194,13 +194,15 @@ class LinkMaterial(Material):
 
 
 class Visual(xmlr.Object):
-    def __init__(self, geometry=None, material=None, origin=None):
+    def __init__(self, geometry=None, material=None, name=None, origin=None):
         self.geometry = geometry
         self.material = material
+        self.name = name
         self.origin = origin
 
 
 xmlr.reflect(Visual, tag='visual', params=[
+    xmlr.Attribute('name', str, False),
     origin_element,
     xmlr.Element('geometry', 'geometric'),
     xmlr.Element('material', LinkMaterial, False)

--- a/test/test_urdf.py
+++ b/test/test_urdf.py
@@ -166,7 +166,7 @@ class TestURDFParser(unittest.TestCase):
 
     def test_visual_with_name(self):
         xml = '''<?xml version="1.0"?>
-<robot name="test">
+<robot name="test" version="1.0">
   <link name="link">
     <visual name="alice">
       <geometry>

--- a/test/test_urdf.py
+++ b/test/test_urdf.py
@@ -164,6 +164,20 @@ class TestURDFParser(unittest.TestCase):
 </robot>'''
         self.parse_and_compare(xml)
 
+    def test_visual_with_name(self):
+        xml = '''<?xml version="1.0"?>
+<robot name="test">
+  <link name="link">
+    <visual name="alice">
+      <geometry>
+        <cylinder length="1" radius="1"/>
+      </geometry>
+      <material name="mat"/>
+    </visual>
+  </link>
+</robot>'''
+        self.parse_and_compare(xml)
+
     def test_link_multiple_collision(self):
         xml = '''<?xml version="1.0"?>
 <robot name="test">


### PR DESCRIPTION
With some URDF like this:
```
    <visual name="tire">
      <origin xyz="0 0.06 0" rpy="${M_PI/2} 0 0" />
      <geometry>
        <mesh filename="${mesh_dir}rp1a_wheel.dae" />
      </geometry>
      <material name="MidGrey"/>
    </visual>
```
I get a warning like this:
```
Unknown attribute "name" in /robot[@name='resource_prospector']/link[@name='front_right_wheel_link']/visual[1]
```
According to the docs, it's valid to have a `name` attribute in a `visual` tag:
http://wiki.ros.org/urdf/XML/link#Elements

In this PR I made changes that I think are in the right direction to add support for that attribute. At least, with these changes, the warning disappears. But I must admit that I'm not certain that I've done the right thing here.

It might also be a good idea to update the schema: https://github.com/ros/urdfdom/blob/master/xsd/urdf.xsd#L123-L133, but I'm not sure whether that's necessary.