### PR TITLE
Remove the usage of lxml

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -25,7 +25,6 @@
 
   <depend>python</depend>
 
-  <exec_depend>python-lxml</exec_depend>
   <exec_depend>python-yaml</exec_depend>
 
   <test_depend>python-mock</test_depend>

--- a/src/urdf_parser_py/xml_reflection/basics.py
+++ b/src/urdf_parser_py/xml_reflection/basics.py
@@ -6,9 +6,6 @@ from xml.etree import ElementTree as ET
 
 
 def xml_string(rootXml, addHeader=True):
-    # Meh
-    # TODO(tfoote) restore pretty_print
-    # xmlString = ET.tostring(rootXml, pretty_print=True)
     xmlString = ET.tostring(rootXml)
     if addHeader:
         xmlString = '<?xml version="1.0"?>\n' + xmlString

--- a/src/urdf_parser_py/xml_reflection/basics.py
+++ b/src/urdf_parser_py/xml_reflection/basics.py
@@ -1,16 +1,15 @@
 import string
 import yaml
 import collections
-from lxml import etree
 
-# Different implementations mix well it seems
-# @todo Do not use this?
-from xml.etree.ElementTree import ElementTree
+from xml.etree import ElementTree as ET
 
 
 def xml_string(rootXml, addHeader=True):
     # Meh
-    xmlString = etree.tostring(rootXml, pretty_print=True)
+    # TODO(tfoote) restore pretty_print
+    # xmlString = ET.tostring(rootXml, pretty_print=True)
+    xmlString = ET.tostring(rootXml)
     if addHeader:
         xmlString = '<?xml version="1.0"?>\n' + xmlString
     return xmlString
@@ -24,7 +23,7 @@ def node_add(doc, sub):
     if sub is None:
         return None
     if type(sub) == str:
-        return etree.SubElement(doc, sub)
+        return ET.SubElement(doc, sub)
     elif isinstance(sub, etree._Element):
         doc.append(sub)  # This screws up the rest of the tree for prettyprint
         return sub
@@ -40,7 +39,7 @@ def xml_children(node):
     children = node.getchildren()
 
     def predicate(node):
-        return not isinstance(node, etree._Comment)
+        return not isinstance(node, type(ET.Comment))
     return list(filter(predicate, children))
 
 
@@ -62,7 +61,7 @@ def to_yaml(obj):
         return obj
     elif hasattr(obj, 'to_yaml'):
         out = obj.to_yaml()
-    elif isinstance(obj, etree._Element):
+    elif isinstance(obj, type(ET.Element)):
         out = etree.tostring(obj, pretty_print=True)
     elif type(obj) == dict:
         out = {}

--- a/src/urdf_parser_py/xml_reflection/core.py
+++ b/src/urdf_parser_py/xml_reflection/core.py
@@ -533,7 +533,6 @@ class Object(YamlReflection):
 
     @classmethod
     def from_xml_string(cls, xml_string):
-        type(ET)
         node = ET.fromstring(xml_string)
         return cls.from_xml(node)
 

--- a/src/urdf_parser_py/xml_reflection/core.py
+++ b/src/urdf_parser_py/xml_reflection/core.py
@@ -511,7 +511,7 @@ class Object(YamlReflection):
         """ Creates an overarching tag and adds its contents to the node """
         tag = self.XML_REFL.tag
         assert tag is not None, "Must define 'tag' in reflection to use this function"  # noqa
-        doc = etree.Element(tag)
+        doc = ET.Element(tag)
         self.write_xml(doc)
         return doc
 
@@ -533,7 +533,8 @@ class Object(YamlReflection):
 
     @classmethod
     def from_xml_string(cls, xml_string):
-        node = etree.fromstring(xml_string)
+        type(ET)
+        node = ET.fromstring(xml_string)
         return cls.from_xml(node)
 
     @classmethod
@@ -585,7 +586,7 @@ class Object(YamlReflection):
     """ Compatibility """
 
     def parse(self, xml_string):
-        node = etree.fromstring(xml_string)
+        node = ET.fromstring(xml_string)
         self.read_xml(node)
         return self
 


### PR DESCRIPTION
We should use the build-in xml parser for fewer dependencies.