### PR TITLE
fix etree.tostring() returning bytes

### DIFF
--- a/src/urdf_parser_py/xml_reflection/basics.py
+++ b/src/urdf_parser_py/xml_reflection/basics.py
@@ -10,7 +10,7 @@ from xml.etree.ElementTree import ElementTree
 
 def xml_string(rootXml, addHeader=True):
     # Meh
-    xmlString = etree.tostring(rootXml, pretty_print=True)
+    xmlString = etree.tostring(rootXml, pretty_print=True, encoding='unicode')
     if addHeader:
         xmlString = '<?xml version="1.0"?>\n' + xmlString
     return xmlString


### PR DESCRIPTION
As per lxml documentation (https://lxml.de/api/lxml.etree-module.html#tostring), etree.tostring() returns bytes by default, which makes this line fail (using python 3.5 and lxml 3.5): 

xmlString = '<?xml version="1.0"?>\n' + xmlString

