### PR TITLE
Add in support for the version tag.

### DIFF
--- a/src/urdf_parser_py/urdf.py
+++ b/src/urdf_parser_py/urdf.py
@@ -535,9 +535,16 @@ class Robot(xmlr.Object):
 
     def post_read_xml(self):
         if self.version is None:
-            self.version = 1.0
+            self.version = "1.0"
 
-        if self.version != 1.0:
+        split = self.version.split(".")
+        if len(split) != 2:
+            raise Exception("The version attribute should be in the form 'x.y'")
+
+        if int(split[0]) < 0 or int(split[1]) < 0:
+            raise Exception("Version number must be positive")
+
+        if self.version != "1.0":
             raise Exception("Invalid version; only 1.0 is supported")
 
     @classmethod
@@ -555,7 +562,7 @@ class Robot(xmlr.Object):
 
 xmlr.reflect(Robot, tag='robot', params=[
     xmlr.Attribute('name', str),
-    xmlr.Attribute('version', float, False),
+    xmlr.Attribute('version', str, False),
     xmlr.AggregateElement('link', Link),
     xmlr.AggregateElement('joint', Joint),
     xmlr.AggregateElement('gazebo', xmlr.RawType()),

--- a/src/urdf_parser_py/urdf.py
+++ b/src/urdf_parser_py/urdf.py
@@ -539,13 +539,16 @@ class Robot(xmlr.Object):
 
         split = self.version.split(".")
         if len(split) != 2:
-            raise Exception("The version attribute should be in the form 'x.y'")
+            raise ValueError("The version attribute should be in the form 'x.y'")
+
+        if split[0] == '' or split[1] == '':
+            raise ValueError("Empty major or minor number is not allowed")
 
         if int(split[0]) < 0 or int(split[1]) < 0:
-            raise Exception("Version number must be positive")
+            raise ValueError("Version number must be positive")
 
         if self.version != "1.0":
-            raise Exception("Invalid version; only 1.0 is supported")
+            raise ValueError("Invalid version; only 1.0 is supported")
 
     @classmethod
     def from_parameter_server(cls, key='robot_description'):

--- a/src/urdf_parser_py/urdf.py
+++ b/src/urdf_parser_py/urdf.py
@@ -533,6 +533,13 @@ class Robot(xmlr.Object):
         assert root is not None, "No roots detected, invalid URDF."
         return root
 
+    def post_read_xml(self):
+        if self.version is None:
+            self.version = 1.0
+
+        if self.version != 1.0:
+            raise Exception("Invalid version; only 1.0 is supported")
+
     @classmethod
     def from_parameter_server(cls, key='robot_description'):
         """
@@ -547,7 +554,8 @@ class Robot(xmlr.Object):
 
 
 xmlr.reflect(Robot, tag='robot', params=[
-    xmlr.Attribute('name', str, False),  # Is 'name' a required attribute?
+    xmlr.Attribute('name', str),
+    xmlr.Attribute('version', float, False),
     xmlr.AggregateElement('link', Link),
     xmlr.AggregateElement('joint', Joint),
     xmlr.AggregateElement('gazebo', xmlr.RawType()),

--- a/test/test_urdf.py
+++ b/test/test_urdf.py
@@ -33,7 +33,7 @@ class TestURDFParser(unittest.TestCase):
 
     def test_new_transmission(self):
         xml = '''<?xml version="1.0"?>
-<robot name="test">
+<robot name="test" version="1.0">
   <transmission name="simple_trans">
     <type>transmission_interface/SimpleTransmission</type>
     <joint name="foo_joint">
@@ -48,7 +48,7 @@ class TestURDFParser(unittest.TestCase):
 
     def test_new_transmission_multiple_joints(self):
         xml = '''<?xml version="1.0"?>
-<robot name="test">
+<robot name="test" version="1.0">
   <transmission name="simple_trans">
     <type>transmission_interface/SimpleTransmission</type>
     <joint name="foo_joint">
@@ -67,7 +67,7 @@ class TestURDFParser(unittest.TestCase):
 
     def test_new_transmission_multiple_actuators(self):
         xml = '''<?xml version="1.0"?>
-<robot name="test">
+<robot name="test" version="1.0">
   <transmission name="simple_trans">
     <type>transmission_interface/SimpleTransmission</type>
     <joint name="foo_joint">
@@ -83,16 +83,16 @@ class TestURDFParser(unittest.TestCase):
 
     def test_new_transmission_missing_joint(self):
         xml = '''<?xml version="1.0"?>
-<robot name="test">
+<robot name="test" version="1.0">
   <transmission name="simple_trans">
     <type>transmission_interface/SimpleTransmission</type>
   </transmission>
 </robot>'''
-        self.assertRaises(Exception, self.parse, xml)
+        self.assertRaises(xmlr.core.ParseError, self.parse, xml)
 
     def test_new_transmission_missing_actuator(self):
         xml = '''<?xml version="1.0"?>
-<robot name="test">
+<robot name="test" version="1.0">
   <transmission name="simple_trans">
     <type>transmission_interface/SimpleTransmission</type>
     <joint name="foo_joint">
@@ -100,11 +100,11 @@ class TestURDFParser(unittest.TestCase):
     </joint>
   </transmission>
 </robot>'''
-        self.assertRaises(Exception, self.parse, xml)
+        self.assertRaises(xmlr.core.ParseError, self.parse, xml)
 
     def test_old_transmission(self):
         xml = '''<?xml version="1.0"?>
-<robot name="test">
+<robot name="test" version="1.0">
   <transmission name="PR2_trans" type="SimpleTransmission">
     <joint name="foo_joint"/>
     <actuator name="foo_motor"/>
@@ -115,7 +115,7 @@ class TestURDFParser(unittest.TestCase):
 
     def test_link_material_missing_color_and_texture(self):
         xml = '''<?xml version="1.0"?>
-<robot name="test">
+<robot name="test" version="1.0">
   <link name="link">
     <visual>
       <geometry>
@@ -129,7 +129,7 @@ class TestURDFParser(unittest.TestCase):
 
     def test_robot_material(self):
         xml = '''<?xml version="1.0"?>
-<robot name="test">
+<robot name="test" version="1.0">
   <material name="mat">
     <color rgba="0.0 0.0 0.0 1.0"/>
   </material>
@@ -138,14 +138,14 @@ class TestURDFParser(unittest.TestCase):
 
     def test_robot_material_missing_color_and_texture(self):
         xml = '''<?xml version="1.0"?>
-<robot name="test">
+<robot name="test" version="1.0">
   <material name="mat"/>
 </robot>'''
-        self.assertRaises(ParseException, self.parse, xml)
+        self.assertRaises(xmlr.core.ParseError, self.parse, xml)
 
     def test_link_multiple_visual(self):
         xml = '''<?xml version="1.0"?>
-<robot name="test">
+<robot name="test" version="1.0">
   <link name="link">
     <visual>
       <geometry>
@@ -165,7 +165,7 @@ class TestURDFParser(unittest.TestCase):
 
     def test_link_multiple_collision(self):
         xml = '''<?xml version="1.0"?>
-<robot name="test">
+<robot name="test" version="1.0">
   <link name="link">
     <collision>
       <geometry>
@@ -181,6 +181,30 @@ class TestURDFParser(unittest.TestCase):
 </robot>'''
         self.parse_and_compare(xml)
 
+    def test_version_attribute_int(self):
+        xml = '''<?xml version="1.0"?>
+<robot name="test" version="1">
+</robot>'''
+        self.parse_and_compare(xml)
+
+    def test_version_attribute_float(self):
+        xml = '''<?xml version="1.0"?>
+<robot name="test" version="1.0">
+</robot>'''
+        self.parse_and_compare(xml)
+
+    def test_version_attribute_invalid(self):
+        xml = '''<?xml version="1.0"?>
+<robot name="test" version="foo">
+</robot>'''
+        #self.assertRaises(xmlr.core.ParseError, self.parse, xml)
+        self.assertRaises(xmlr.core.ParseError, self.parse, xml)
+
+    def test_version_attribute_invalid_version(self):
+        xml = '''<?xml version="1.0"?>
+<robot name="test" version="2.0">
+</robot>'''
+        self.assertRaises(Exception, self.parse, xml)
 
 class LinkOriginTestCase(unittest.TestCase):
     @mock.patch('urdf_parser_py.xml_reflection.on_error',

--- a/test/test_urdf.py
+++ b/test/test_urdf.py
@@ -185,55 +185,55 @@ class TestURDFParser(unittest.TestCase):
         xml = '''<?xml version="1.0"?>
 <robot name="test" version="1">
 </robot>'''
-        self.assertRaises(Exception, self.parse, xml)
+        self.assertRaises(ValueError, self.parse, xml)
 
     def test_version_attribute_too_many_dots(self):
         xml = '''<?xml version="1.0"?>
 <robot name="test" version="1.0.0">
 </robot>'''
-        self.assertRaises(Exception, self.parse, xml)
+        self.assertRaises(ValueError, self.parse, xml)
 
     def test_version_attribute_not_enough_numbers(self):
         xml = '''<?xml version="1.0"?>
 <robot name="test" version="1.">
 </robot>'''
-        self.assertRaises(Exception, self.parse, xml)
+        self.assertRaises(ValueError, self.parse, xml)
 
     def test_version_attribute_no_major_number(self):
         xml = '''<?xml version="1.0"?>
-<robot name="test" version="1.">
+<robot name="test" version=".0">
 </robot>'''
-        self.assertRaises(Exception, self.parse, xml)
+        self.assertRaises(ValueError, self.parse, xml)
 
     def test_version_attribute_negative_major_number(self):
         xml = '''<?xml version="1.0"?>
 <robot name="test" version="-1.0">
 </robot>'''
-        self.assertRaises(Exception, self.parse, xml)
+        self.assertRaises(ValueError, self.parse, xml)
 
     def test_version_attribute_negative_minor_number(self):
         xml = '''<?xml version="1.0"?>
-<robot name="test" version="-1.0">
+<robot name="test" version="1.-0">
 </robot>'''
-        self.assertRaises(Exception, self.parse, xml)
+        self.assertRaises(ValueError, self.parse, xml)
 
     def test_version_attribute_dots_no_numbers(self):
         xml = '''<?xml version="1.0"?>
 <robot name="test" version="a.c">
 </robot>'''
-        self.assertRaises(Exception, self.parse, xml)
+        self.assertRaises(ValueError, self.parse, xml)
 
     def test_version_attribute_dots_one_number(self):
         xml = '''<?xml version="1.0"?>
 <robot name="test" version="1.c">
 </robot>'''
-        self.assertRaises(Exception, self.parse, xml)
+        self.assertRaises(ValueError, self.parse, xml)
 
     def test_version_attribute_trailing_junk(self):
         xml = '''<?xml version="1.0"?>
 <robot name="test" version="1.0~pre6">
 </robot>'''
-        self.assertRaises(Exception, self.parse, xml)
+        self.assertRaises(ValueError, self.parse, xml)
 
     def test_version_attribute_correct(self):
         xml = '''<?xml version="1.0"?>
@@ -245,13 +245,13 @@ class TestURDFParser(unittest.TestCase):
         xml = '''<?xml version="1.0"?>
 <robot name="test" version="foo">
 </robot>'''
-        self.assertRaises(Exception, self.parse, xml)
+        self.assertRaises(ValueError, self.parse, xml)
 
     def test_version_attribute_invalid_version(self):
         xml = '''<?xml version="1.0"?>
 <robot name="test" version="2.0">
 </robot>'''
-        self.assertRaises(Exception, self.parse, xml)
+        self.assertRaises(ValueError, self.parse, xml)
 
 class LinkOriginTestCase(unittest.TestCase):
     @mock.patch('urdf_parser_py.xml_reflection.on_error',

--- a/test/test_urdf.py
+++ b/test/test_urdf.py
@@ -181,13 +181,61 @@ class TestURDFParser(unittest.TestCase):
 </robot>'''
         self.parse_and_compare(xml)
 
-    def test_version_attribute_int(self):
+    def test_version_attribute_not_enough_dots(self):
         xml = '''<?xml version="1.0"?>
 <robot name="test" version="1">
 </robot>'''
-        self.parse_and_compare(xml)
+        self.assertRaises(Exception, self.parse, xml)
 
-    def test_version_attribute_float(self):
+    def test_version_attribute_too_many_dots(self):
+        xml = '''<?xml version="1.0"?>
+<robot name="test" version="1.0.0">
+</robot>'''
+        self.assertRaises(Exception, self.parse, xml)
+
+    def test_version_attribute_not_enough_numbers(self):
+        xml = '''<?xml version="1.0"?>
+<robot name="test" version="1.">
+</robot>'''
+        self.assertRaises(Exception, self.parse, xml)
+
+    def test_version_attribute_no_major_number(self):
+        xml = '''<?xml version="1.0"?>
+<robot name="test" version="1.">
+</robot>'''
+        self.assertRaises(Exception, self.parse, xml)
+
+    def test_version_attribute_negative_major_number(self):
+        xml = '''<?xml version="1.0"?>
+<robot name="test" version="-1.0">
+</robot>'''
+        self.assertRaises(Exception, self.parse, xml)
+
+    def test_version_attribute_negative_minor_number(self):
+        xml = '''<?xml version="1.0"?>
+<robot name="test" version="-1.0">
+</robot>'''
+        self.assertRaises(Exception, self.parse, xml)
+
+    def test_version_attribute_dots_no_numbers(self):
+        xml = '''<?xml version="1.0"?>
+<robot name="test" version="a.c">
+</robot>'''
+        self.assertRaises(Exception, self.parse, xml)
+
+    def test_version_attribute_dots_one_number(self):
+        xml = '''<?xml version="1.0"?>
+<robot name="test" version="1.c">
+</robot>'''
+        self.assertRaises(Exception, self.parse, xml)
+
+    def test_version_attribute_trailing_junk(self):
+        xml = '''<?xml version="1.0"?>
+<robot name="test" version="1.0~pre6">
+</robot>'''
+        self.assertRaises(Exception, self.parse, xml)
+
+    def test_version_attribute_correct(self):
         xml = '''<?xml version="1.0"?>
 <robot name="test" version="1.0">
 </robot>'''
@@ -197,8 +245,7 @@ class TestURDFParser(unittest.TestCase):
         xml = '''<?xml version="1.0"?>
 <robot name="test" version="foo">
 </robot>'''
-        #self.assertRaises(xmlr.core.ParseError, self.parse, xml)
-        self.assertRaises(xmlr.core.ParseError, self.parse, xml)
+        self.assertRaises(Exception, self.parse, xml)
 
     def test_version_attribute_invalid_version(self):
         xml = '''<?xml version="1.0"?>


### PR DESCRIPTION
Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

Just like in [urdfdom](https://github.com/ros/urdfdom/pull/133), add support for the version tag in the URDF XML.  Note that I ended up adding the `version` tag by hand to all of the round-trip tests so that they pass; there are other tests that test the lack of a `version` tag, so I think this is fine.  @sloretz @scpeters FYI.