### PR TITLE
Use setuptools instead of distutils

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -22,6 +22,8 @@
   <url type="repository">https://github.com/ros/urdf_parser_py</url>
 
   <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend condition="$ROS_PYTHON_VERSION == 2">python-setuptools</buildtool_depend>
+  <buildtool_depend condition="$ROS_PYTHON_VERSION == 3">python3-setuptools</buildtool_depend>
 
   <exec_depend>rospy</exec_depend>
 

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from distutils.core import setup
+from setuptools import setup
 from catkin_pkg.python_setup import generate_distutils_setup
 
 d = generate_distutils_setup(


### PR DESCRIPTION
Since ros/catkin#1048 catkin prefers to use `setuptools` instead of `distutils`. The `package.xml` must include `<buildexport_depend>` tags for `python-setuptools` because in ROS Melodic catkin doesn't export that build dependency. I also included a `<buildtool_depend>` for `python3-setuptools`, which [while catkin does export it](https://github.com/ros/catkin/blob/86439ec5d2010d5c47c30b815aa97e525037930f/package.xml#L32), it makes it clear looking at this `package.xml` in isolation that `setuptools` is required in both cases.