### PR TITLE
Replace deprecated function

### DIFF
--- a/src/urdf_parser_py/xml_reflection/basics.py
+++ b/src/urdf_parser_py/xml_reflection/basics.py
@@ -39,7 +39,7 @@ def pfloat(x):
 
 
 def xml_children(node):
-    return node.getchildren()
+    return list(node)
 
 
 def isstring(obj):


### PR DESCRIPTION
The function `xml_children()` contained a deprecated function from `xml.etree` which results in the following deprecation warning:
```
DeprecationWarning: This method will be removed in future versions.  Use 'list(elem)' or iteration over elem instead.
```

In this PR the function is replaced according to the suggestion made in the generated deprecation warning