### PR TITLE
Make sure to add the version when creating a new URDF.

### DIFF
--- a/src/urdf_parser_py/urdf.py
+++ b/src/urdf_parser_py/urdf.py
@@ -471,10 +471,16 @@ xmlr.add_type('transmission',
 
 
 class Robot(xmlr.Object):
-    def __init__(self, name=None):
+    SUPPORTED_VERSIONS = ["1.0"]
+
+    def __init__(self, name=None, version="1.0"):
         self.aggregate_init()
 
         self.name = name
+        if version not in self.SUPPORTED_VERSIONS:
+            raise ValueError("Invalid version; only %s is supported" % (','.join(self.SUPPORTED_VERSIONS)))
+
+        self.version = version
         self.joints = []
         self.links = []
         self.materials = []
@@ -547,8 +553,8 @@ class Robot(xmlr.Object):
         if int(split[0]) < 0 or int(split[1]) < 0:
             raise ValueError("Version number must be positive")
 
-        if self.version != "1.0":
-            raise ValueError("Invalid version; only 1.0 is supported")
+        if self.version not in self.SUPPORTED_VERSIONS:
+            raise ValueError("Invalid version; only %s is supported" % (','.join(self.SUPPORTED_VERSIONS)))
 
     @classmethod
     def from_parameter_server(cls, key='robot_description'):

--- a/test/test_urdf.py
+++ b/test/test_urdf.py
@@ -346,5 +346,21 @@ class LinkMultiVisualsAndCollisionsTest(unittest.TestCase):
         self.assertEqual(id(dummyObject), id(robot.links[0].collisions[0]))
 
 
+class TestCreateNew(unittest.TestCase):
+    def test_new_urdf(self):
+        testcase = urdf.URDF('robot_name').to_xml()
+        self.assertTrue('name' in testcase.keys())
+        self.assertTrue('version' in testcase.keys())
+        self.assertEqual(testcase.get('name'), 'robot_name')
+        self.assertEqual(testcase.get('version'), '1.0')
+
+    def test_new_urdf_with_version(self):
+        testcase = urdf.URDF('robot_name', '1.0').to_xml()
+        self.assertTrue('name' in testcase.keys())
+        self.assertTrue('version' in testcase.keys())
+        self.assertEqual(testcase.get('name'), 'robot_name')
+        self.assertEqual(testcase.get('version'), '1.0')
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
It turns out that when I added the version stuff, I completely
forgot about creating a new URDF.  This PR fixes it so that
we can successfully round-trip through the URDF parser, and
adds tests to ensure the same.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

Note that once this is reviewed, approved, and merged, I'll do a similar fix for the ROS 1 code.  This should fix #59 