### PR TITLE
Support name attribute for collisions

### DIFF
--- a/src/urdf_parser_py/urdf.py
+++ b/src/urdf_parser_py/urdf.py
@@ -149,12 +149,14 @@ xmlr.add_type('geometric', GeometricType())
 
 
 class Collision(xmlr.Object):
-    def __init__(self, geometry=None, origin=None):
+    def __init__(self, geometry=None, origin=None, name=None):
         self.geometry = geometry
+        self.name = name
         self.origin = origin
 
 
 xmlr.reflect(Collision, tag='collision', params=[
+    xmlr.Attribute('name', str, False),
     origin_element,
     xmlr.Element('geometry', 'geometric')
 ])

--- a/test/test_urdf.py
+++ b/test/test_urdf.py
@@ -283,6 +283,19 @@ class TestURDFParser(unittest.TestCase):
         robot.add_link(link)
         self.xml_and_compare(robot, xml)
 
+    def test_collision_with_name(self):
+        xml = '''<?xml version="1.0"?>
+<robot name="test" version="1.0">
+  <link name="link">
+    <collision name="alice">
+      <geometry>
+        <cylinder length="1" radius="1"/>
+      </geometry>
+    </collision>
+  </link>
+</robot>'''
+        self.parse_and_compare(xml)
+
     def test_version_attribute_not_enough_dots(self):
         xml = '''<?xml version="1.0"?>
 <robot name="test" version="1">


### PR DESCRIPTION
I added the name attribute in Collision, which interestingly enough, was only present in Visual.