### PR TITLE
Get Iterable from collections.abc.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,4 @@
 [develop]
-script-dir=$base/share/urdfdom_py/scripts
+script_dir=$base/share/urdfdom_py/scripts
 [install]
-install-scripts=$base/share/urdfdom_py/scripts
+install_scripts=$base/share/urdfdom_py/scripts

--- a/src/urdf_parser_py/xml_reflection/basics.py
+++ b/src/urdf_parser_py/xml_reflection/basics.py
@@ -1,6 +1,6 @@
 import string
 import yaml
-import collections
+import collections.abc
 from lxml import etree
 
 def xml_string(rootXml, addHeader=True):
@@ -66,7 +66,7 @@ def to_yaml(obj):
     elif hasattr(obj, 'tolist'):
         # For numpy objects
         out = to_yaml(obj.tolist())
-    elif isinstance(obj, collections.Iterable):
+    elif isinstance(obj, collections.abc.Iterable):
         out = [to_yaml(item) for item in obj]
     else:
         out = str(obj)


### PR DESCRIPTION
Getting Iterable from collections was deprecated in Python 3.9 and removed in 3.10.

While I was in here, I noticed that we were getting warnings for a deprecated usage of `script-dir` and `install-scripts`, so fix that as well.

Fixes #72 