### PR TITLE
Fix the binary install location.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,4 @@
 [develop]
-script_dir=$base/share/urdfdom_py/scripts
+script_dir=$base/lib/urdfdom_py
 [install]
-install_scripts=$base/share/urdfdom_py/scripts
+install_scripts=$base/lib/urdfdom_py


### PR DESCRIPTION
The previous one was wrong.  With this fix in place,
'ros2 run urdfdom_py display_urdf' now works.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>