### PR TITLE
Switch to unittest.mock

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -25,7 +25,6 @@
 
   <exec_depend>python3-lxml</exec_depend>
   <exec_depend>python3-yaml</exec_depend>
-  <test_depend>python3-mock</test_depend>
 
   <export>
     <build_type>ament_python</build_type>

--- a/test/test_urdf.py
+++ b/test/test_urdf.py
@@ -1,6 +1,6 @@
 
 import unittest
-import mock
+from unittest import mock
 import os
 import sys
 


### PR DESCRIPTION
The mock package has been integrated into unittest since Python 3.3, which includes all supported distributions of ROS 2.

Should resolve the current build failures on RHEL 9: https://build.ros2.org/view/Rbin_rhel_el964/job/Rbin_rhel_el964__urdfdom_py__rhel_9_x86_64__binary/