### PR TITLE
Link Visual and Collision are not exported to XML

### DIFF
--- a/src/urdf_parser_py/urdf.py
+++ b/src/urdf_parser_py/urdf.py
@@ -355,8 +355,12 @@ class Link(xmlr.Object):
         self.aggregate_init()
         self.name = name
         self.visuals = []
+        if visual:
+            self.visual = visual
         self.inertial = inertial
         self.collisions = []
+        if collision:
+            self.collision = collision
         self.origin = origin
 
     def __get_visual(self):
@@ -370,6 +374,8 @@ class Link(xmlr.Object):
             self.visuals[0] = visual
         else:
             self.visuals.append(visual)
+        if visual:
+            self.add_aggregate('visual', visual)
 
     def __get_collision(self):
         """Return the first collision or None."""
@@ -382,6 +388,8 @@ class Link(xmlr.Object):
             self.collisions[0] = collision
         else:
             self.collisions.append(collision)
+        if collision:
+            self.add_aggregate('collision', collision)
 
     # Properties for backwards compatibility
     visual = property(__get_visual, __set_visual)

--- a/src/urdf_parser_py/urdf.py
+++ b/src/urdf_parser_py/urdf.py
@@ -334,6 +334,7 @@ class Joint(xmlr.Object):
     @joint_type.setter
     def joint_type(self, value): self.type = value
 
+
 xmlr.reflect(Joint, tag='joint', params=[
     name_attribute,
     xmlr.Attribute('type', str),
@@ -377,13 +378,19 @@ class Link(xmlr.Object):
 
     def add_visual(self, visual):
         """Add a visual element to the link."""
-        self.visuals.append(visual)
-        self.add_aggregate('visual', self.visuals[-1])
+        self.add_aggregate('visual', visual)
+
+    def remove_visual(self, visual):
+        """Removes the provided visual object."""
+        self.remove_aggregate(visual)
 
     def add_collision(self, collision):
         """Add a collision element for the link."""
-        self.collisions.append(collision)
-        self.add_aggregate('collision', self.collisions[-1])
+        self.add_aggregate('collision', collision)
+
+    def remove_collision(self, collision):
+        """Removes a provided collision object."""
+        self.remove_aggregate(collision)
 
     def __get_collision(self):
         """Return the first collision or None."""
@@ -492,7 +499,8 @@ class Robot(xmlr.Object):
 
         self.name = name
         if version not in self.SUPPORTED_VERSIONS:
-            raise ValueError("Invalid version; only %s is supported" % (','.join(self.SUPPORTED_VERSIONS)))
+            raise ValueError("Invalid version; only %s is supported" %
+                             (','.join(self.SUPPORTED_VERSIONS)))
 
         self.version = version
         self.joints = []
@@ -568,7 +576,8 @@ class Robot(xmlr.Object):
             raise ValueError("Version number must be positive")
 
         if self.version not in self.SUPPORTED_VERSIONS:
-            raise ValueError("Invalid version; only %s is supported" % (','.join(self.SUPPORTED_VERSIONS)))
+            raise ValueError("Invalid version; only %s is supported" %
+                             (','.join(self.SUPPORTED_VERSIONS)))
 
 
 xmlr.reflect(Robot, tag='robot', params=[

--- a/src/urdf_parser_py/urdf.py
+++ b/src/urdf_parser_py/urdf.py
@@ -371,11 +371,19 @@ class Link(xmlr.Object):
     def __set_visual(self, visual):
         """Set the first visual."""
         if self.visuals:
-            self.visuals[0] = visual
-        else:
-            self.visuals.append(visual)
+            self.remove_aggregate(self.visuals[0])
         if visual:
             self.add_aggregate('visual', visual)
+
+    def add_visual(self, visual):
+        """Add a visual element to the link."""
+        self.visuals.append(visual)
+        self.add_aggregate('visual', self.visuals[-1])
+
+    def add_collision(self, collision):
+        """Add a collision element for the link."""
+        self.collisions.append(collision)
+        self.add_aggregate('collision', self.collisions[-1])
 
     def __get_collision(self):
         """Return the first collision or None."""
@@ -385,9 +393,7 @@ class Link(xmlr.Object):
     def __set_collision(self, collision):
         """Set the first collision."""
         if self.collisions:
-            self.collisions[0] = collision
-        else:
-            self.collisions.append(collision)
+            self.remove_aggregate(self.collisions[0])
         if collision:
             self.add_aggregate('collision', collision)
 

--- a/test/test_urdf.py
+++ b/test/test_urdf.py
@@ -237,10 +237,10 @@ class TestURDFParser(unittest.TestCase):
 
         robot = urdf.Robot(name='test', version='1.0')
         link = urdf.Link(name='link')
-        link.visual = urdf.Visual(geometry=urdf.Cylinder(length=1, radius=1),
-                                  material=urdf.Material(name='mat'))
-        link.visual = urdf.Visual(geometry=urdf.Cylinder(length=4, radius=0.5),
-                                  material=urdf.Material(name='mat2'))
+        link.add_visual(urdf.Visual(geometry=urdf.Cylinder(length=1, radius=1),
+                                  material=urdf.Material(name='mat')))
+        link.add_visual(urdf.Visual(geometry=urdf.Cylinder(length=4, radius=0.5),
+                                  material=urdf.Material(name='mat2')))
         robot.add_link(link)
         self.xml_and_compare(robot, xml)
 
@@ -264,8 +264,8 @@ class TestURDFParser(unittest.TestCase):
 
         robot = urdf.Robot(name='test', version='1.0')
         link = urdf.Link(name='link')
-        link.collision = urdf.Collision(geometry=urdf.Cylinder(length=1, radius=1))
-        link.collision = urdf.Collision(geometry=urdf.Cylinder(length=4, radius=0.5))
+        link.add_collision(urdf.Collision(geometry=urdf.Cylinder(length=1, radius=1)))
+        link.add_collision(urdf.Collision(geometry=urdf.Cylinder(length=4, radius=0.5)))
         robot.add_link(link)
         self.xml_and_compare(robot, xml)
 
@@ -418,7 +418,7 @@ class LinkMultiVisualsAndCollisionsTest(unittest.TestCase):
         self.assertEqual(None, robot.links[1].visual)
 
         dummyObject = set()
-        robot.links[0].visual = dummyObject
+        robot.links[0].visuals[0] = dummyObject
         self.assertEqual(id(dummyObject), id(robot.links[0].visuals[0]))
 
     def test_multi_collision_access(self):
@@ -430,18 +430,18 @@ class LinkMultiVisualsAndCollisionsTest(unittest.TestCase):
         self.assertEqual(None, robot.links[1].collision)
 
         dummyObject = set()
-        robot.links[0].collision = dummyObject
+        robot.links[0].collisions[0] = dummyObject
         self.assertEqual(id(dummyObject), id(robot.links[0].collisions[0]))
 
     def test_xml_and_urdfdom_robot_compatible_with_kinetic(self):
         robot = urdf.Robot(name='test', version='1.0')
         link = urdf.Link(name='link')
-        link.visual = urdf.Visual(geometry=urdf.Cylinder(length=1, radius=1),
-                                  material=urdf.Material(name='mat'))
-        link.visual = urdf.Visual(geometry=urdf.Cylinder(length=4, radius=0.5),
-                                  material=urdf.Material(name='mat2'))
-        link.collision = urdf.Collision(geometry=urdf.Cylinder(length=1, radius=1))
-        link.collision = urdf.Collision(geometry=urdf.Cylinder(length=4, radius=0.5))
+        link.add_visual(urdf.Visual(geometry=urdf.Cylinder(length=1, radius=1),
+                                  material=urdf.Material(name='mat')))
+        link.add_visual(urdf.Visual(geometry=urdf.Cylinder(length=4, radius=0.5),
+                                  material=urdf.Material(name='mat2')))
+        link.add_collision(urdf.Collision(geometry=urdf.Cylinder(length=1, radius=1)))
+        link.add_collision(urdf.Collision(geometry=urdf.Cylinder(length=4, radius=0.5)))
         robot.add_link(link)
         link = urdf.Link(name='link2')
         robot.add_link(link)

--- a/test/test_urdf.py
+++ b/test/test_urdf.py
@@ -244,20 +244,6 @@ class TestURDFParser(unittest.TestCase):
         robot.add_link(link)
         self.xml_and_compare(robot, xml)
 
-    def test_visual_with_name(self):
-        xml = '''<?xml version="1.0"?>
-<robot name="test" version="1.0">
-  <link name="link">
-    <visual name="alice">
-      <geometry>
-        <cylinder length="1" radius="1"/>
-      </geometry>
-      <material name="mat"/>
-    </visual>
-  </link>
-</robot>'''
-        self.parse_and_compare(xml)
-
     def test_link_multiple_collision(self):
         xml = '''<?xml version="1.0"?>
 <robot name="test" version="1.0">


### PR DESCRIPTION
I realized, that Visual and Collision are not exported to XML, if they are set via the Constructor.
There is also an open issue for it #42.
In addition, I realized that this issue was already fixed on the melodic-branch, see pull request #47.

Consequently, I cherry-pick the changes introduced with #47. In addition, I had to remove one test, since the `Visual` class does not have an attribute `name` anymore.


Closes: #42
Relates: #47