### PR TITLE
Fix UTF8 reading.

### DIFF
--- a/src/urdf_parser_py/display_urdf.py
+++ b/src/urdf_parser_py/display_urdf.py
@@ -6,7 +6,7 @@ from urdf_parser_py.urdf import URDF
 
 def main():
     parser = argparse.ArgumentParser(usage='Load an URDF file')
-    parser.add_argument('file', type=argparse.FileType('r'),
+    parser.add_argument('file', type=argparse.FileType('rb'),
                         help='File to load. Use - for stdin')
     parser.add_argument('-o', '--output', type=argparse.FileType('w'),
                         default=None, help='Dump file to XML')

--- a/src/urdf_parser_py/xml_reflection/core.py
+++ b/src/urdf_parser_py/xml_reflection/core.py
@@ -613,7 +613,7 @@ class Object(YamlReflection):
 
     @classmethod
     def from_xml_file(cls, file_path):
-        xml_string = open(file_path, 'r').read()
+        xml_string = open(file_path, 'rb').read()
         return cls.from_xml_string(xml_string)
 
     # Confusing distinction between loading code in object and reflection

--- a/test/test_urdf.py
+++ b/test/test_urdf.py
@@ -289,6 +289,21 @@ class LinkOriginTestCase(unittest.TestCase):
         self.assertEqual(origin.xyz, [1, 2, 3])
         self.assertEqual(origin.rpy, [0, 0, 0])
 
+    def test_xml_with_UTF8_encoding(self):
+        xml = b'''<?xml version="1.0" encoding="UTF-8"?>
+<robot name="test">
+  <link name="test_link">
+    <inertial>
+      <mass value="10.0"/>
+      <origin xyz="1 2 3"/>
+    </inertial>
+  </link>
+</robot>'''
+        robot = self.parse(xml)
+        origin = robot.links[0].inertial.origin
+        self.assertEqual(origin.xyz, [1, 2, 3])
+        self.assertEqual(origin.rpy, [0, 0, 0])
+
 
 class LinkMultiVisualsAndCollisionsTest(unittest.TestCase):
 


### PR DESCRIPTION
Do this by opening files in binary mode, which will allow the XML parser to convert to UTF-8 if it is specified.

This should fix #82 