### PR TITLE
Allow name attribute in visual and collision tag [ros2 branch]

### DIFF
--- a/src/urdf_parser_py/urdf.py
+++ b/src/urdf_parser_py/urdf.py
@@ -194,13 +194,15 @@ class LinkMaterial(Material):
 
 
 class Visual(xmlr.Object):
-    def __init__(self, geometry=None, material=None, origin=None):
+    def __init__(self, geometry=None, material=None, origin=None, name=None):
         self.geometry = geometry
         self.material = material
+        self.name = name
         self.origin = origin
 
 
 xmlr.reflect(Visual, tag='visual', params=[
+    xmlr.Attribute('name', str, False),
     origin_element,
     xmlr.Element('geometry', 'geometric'),
     xmlr.Element('material', LinkMaterial, False)

--- a/src/urdf_parser_py/urdf.py
+++ b/src/urdf_parser_py/urdf.py
@@ -149,12 +149,14 @@ xmlr.add_type('geometric', GeometricType())
 
 
 class Collision(xmlr.Object):
-    def __init__(self, geometry=None, origin=None):
+    def __init__(self, geometry=None, origin=None, name=None):
         self.geometry = geometry
+        self.name = name
         self.origin = origin
 
 
 xmlr.reflect(Collision, tag='collision', params=[
+    xmlr.Attribute('name', str, False),
     origin_element,
     xmlr.Element('geometry', 'geometric')
 ])

--- a/test/test_urdf.py
+++ b/test/test_urdf.py
@@ -195,6 +195,19 @@ class TestURDFParser(unittest.TestCase):
 </robot>'''
         self.parse_and_compare(xml)
 
+    def test_collision_with_name(self):
+        xml = '''<?xml version="1.0"?>
+<robot name="test" version="1.0">
+  <link name="link">
+    <collision name="alice">
+      <geometry>
+        <cylinder length="1" radius="1"/>
+      </geometry>
+    </collision>
+  </link>
+</robot>'''
+        self.parse_and_compare(xml)
+
     def test_version_attribute_not_enough_dots(self):
         xml = '''<?xml version="1.0"?>
 <robot name="test" version="1">

--- a/test/test_urdf.py
+++ b/test/test_urdf.py
@@ -163,6 +163,20 @@ class TestURDFParser(unittest.TestCase):
 </robot>'''
         self.parse_and_compare(xml)
 
+    def test_visual_with_name(self):
+        xml = '''<?xml version="1.0"?>
+<robot name="test" version="1.0">
+  <link name="link">
+    <visual name="alice">
+      <geometry>
+        <cylinder length="1" radius="1"/>
+      </geometry>
+      <material name="mat"/>
+    </visual>
+  </link>
+</robot>'''
+        self.parse_and_compare(xml)
+
     def test_link_multiple_collision(self):
         xml = '''<?xml version="1.0"?>
 <robot name="test" version="1.0">


### PR DESCRIPTION
This fix is necessary to ensure that the parser is consistent with the URDF spec. The issue was solved in https://github.com/ros/urdf_parser_py/pull/31 and https://github.com/ros/urdf_parser_py/pull/67 for the `melodic-devel` branch, but the changes were never cherry-picked or forward merged to the `ros2` branch.