### PR TITLE
Fix name of BSD PyPI classifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     keywords=['ROS2'],
     classifiers=[
         'Intended Audience :: Developers',
-        'License :: OSI Approved :: BSD',
+        'License :: OSI Approved :: BSD License',
         'Programming Language :: Python',
         'Topic :: Software Development',
     ],


### PR DESCRIPTION
The correct name is `License :: OSI Approved :: BSD License`, see https://pypi.org/classifiers/ .

This prevents errors when trying to upload the package to a PyPI-like registry.