### PR TITLE
fix setuptools deprecation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,6 @@ setup(
     keywords=['ROS2'],
     classifiers=[
         'Intended Audience :: Developers',
-        'License :: OSI Approved :: BSD License',
         'Programming Language :: Python',
         'Topic :: Software Development',
     ],


### PR DESCRIPTION
fix setuptools deprecations.
Remove old definition.
New definition is already defined in row ~27 :license= 'BSD'